### PR TITLE
New generate reset key subcommand and minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,6 @@ else
 	CRYPTO_OBJ = $(patsubst %,$(SKIBOOTOBJDIR)/%, $(_CRYPTO_OBJ))
 	OBJ += $(CRYPTO_OBJ)
 endif
-# OBJDIR=obj
-# OBJ=$(patsubst %, $(OBJDIR)/%,$(_OBJ))
 
 
 secvarctl: $(OBJ) 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ OBJ +=$(SKIBOOT_OBJ) $(EXTRAMBEDTLS)
 
 OBJCOV = $(patsubst %.o, %.cov.o,$(OBJ))
 
-
+MANDIR=usr/local/share/
 #use STATIC=1 for static build
 STATIC = 0
 ifeq ($(STATIC),1)
@@ -72,6 +72,6 @@ secvarctl-cov: $(OBJCOV)
 install: secvarctl
 	mkdir -p $(DESTDIR)/usr/bin
 	install -m 0755 secvarctl $(DESTDIR)/usr/bin/secvarctl
-	mkdir -p $(DESTDIR)/usr/local/share/man
-	mkdir -p $(DESTDIR)/usr/local/share/man/man1
-	install -m 0755 secvarctl.1 $(DESTDIR)/usr/local/share/man/man1
+	mkdir -p $(DESTDIR)/$(MANDIR)/man
+	mkdir -p $(DESTDIR)/$(MANDIR)/man/man1
+	install -m 0755 secvarctl.1 $(DESTDIR)/$(MANDIR)/man/man1

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #_*_MakeFile_*_
 CC = gcc 
-_CFLAGS = -Os -s -g -std=gnu99
+_CFLAGS = -O2 -s -g -std=gnu99
 LFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto -Wall -Werror 
 
 _DEPEN = secvarctl.h prlog.h err.h generic.h 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
      - From a hash: `$secvarctl generate h:e -h <hashAlgUsed> -i <inputHash> -o <out.esl>`  
      - From a generic file (hash done internally) : `$secvarctl generate f:e -h <hashAlgToUse> -i <inputFile> -o <out.esl>`   
    + Signed Auth File (EXPERIMENTAL):    
-     - From an ESL: `$secvarctl generate e:a -k <signerPrivate.key> -c <signerPublic.key> -n <varName> -i <inputESL> -o <out.auth> `   
-     - From an x509 (ESL created internally): `$secvarctl generate c:a -k <signerPrivate.key> -c <signerPublic.key> -n <varName> -i <inputCert> -o <out.auth> `   
-     - From a hash (ESL created internally): `$secvarctl generate h:a -k <signerPrivate.key> -c <signerPublic.key> -n <varName> -h <hashAlgUsed> -i <inputHash> -o <out.auth> `   
-     - From a file (hash->ESL created internally): `$secvarctl generate f:a -k <signerPrivate.key> -c <signerPublic.key> -n <varName> -h <hashAlgUsed> -i <inputFile> -o <out.auth> `  
+     - From an ESL: `$secvarctl generate e:a -k <signerPrivate.key> -c <signerPublic.crt> -n <varName> -i <inputESL> -o <out.auth> `   
+     - From an x509 (ESL created internally): `$secvarctl generate c:a -k <signerPrivate.key> -c <signerPublic.crt> -n <varName> -i <inputCert> -o <out.auth> `   
+     - From a hash (ESL created internally): `$secvarctl generate h:a -k <signerPrivate.key> -c <signerPublic.crt> -n <varName> -h <hashAlgUsed> -i <inputHash> -o <out.auth> `   
+     - From a file (hash->ESL created internally): `$secvarctl generate f:a -k <signerPrivate.key> -c <signerPublic.crt> -n <varName> -h <hashAlgUsed> -i <inputFile> -o <out.auth> `  
+     - To create a variable reset file: `$secvarctl generate reset -k <signerPrivate.key> -c <signerPublic.crt> -n <varName> -o <out.auth> `
+
 
 ## USAGE:    
   Secvarctl has 5 main commands   
@@ -167,6 +169,9 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
 		-h <hashAlg> hash function, used when output or input format is [h]ash, current <hashAlg> are : {'SHA256', 'SHA224', 'SHA1', 'SHA384', 'SHA512'}
 		-k <privKey> , private key, used when generating [p]kcs7 or [a]uth file
 		-c <certFile> , x509 certificate (PEM), used when generating [p]kcs7 or [a]uth file
+		reset , generates a valid variable reset file, replaces <inputFormat>:<outputFormat>. 
+			This file is just an auth file with an empty ESL. Required arguments are output file, signer crt/key pair and variable name. 
+			No input file required.
 
 
 	<inputFormat>:
@@ -191,6 +196,8 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
 		A PKCS7 and Auth file can be signed with several signers by adding more ' -k <privKey> -c <cert>' pairs. 
 		Additionaly, when generating an Auth file the secure variable name must be given as -n <keyName> because it is included in the  message digest. 
 		When using the input type '[f]ile' it will be assumed to be a text file and if output file is '[e]sl', '[p]kcs7' or '[a]uth' it will be hashed according to <hashAlg> (default SHA256). 
+		To create a variable reset file (one that will remove the current contents of a variable), replace '<inputFormat>:<outputFormat>' with 'reset' and
+		supply a variable name, public and private signer files and an output file with '-n <keyName> -k <privKey> -c <crtFile> -o <outFile>'
 		GENERATION OF PKCS7 AND AUTH FILES ARE IN EXPERIMENTAL DEVELEPOMENT PHASE. THEY HAVE NOT BEEN THOROUGHLY TESTED YET.
 
       

--- a/backends/edk2-compat/edk2-svc-generate.c
+++ b/backends/edk2-compat/edk2-svc-generate.c
@@ -552,7 +552,7 @@ static int generateESL(const char* buff, size_t size, struct Arguments *args, co
 	}
 	//if input file is auth than extract it
 	if (args->inForm[0] == 'a') 
-		authToESL(*inpPtr, inpSize, outBuff, outBuffSize);
+		rc = authToESL(*inpPtr, inpSize, outBuff, outBuffSize);
 	else
 	// now we have either a hash or x509 in der and is ready to be put into an ESL
 		rc = toESL(*inpPtr, inpSize, *eslGUID, outBuff, outBuffSize);

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -478,6 +478,10 @@ int validateCert(const char *certBuf, size_t buflen, const char *varName)
 	mbedtls_x509_crt *x509;
 	int rc;
 
+	if (buflen == 0) {
+		prlog(PR_ERR, "ERROR: Length %zd is invalid\n", buflen);
+		return CERT_FAIL;
+	}
 	x509 = malloc(sizeof(*x509));
 	if (!x509){
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
@@ -578,16 +582,16 @@ int parseX509(mbedtls_x509_crt *x509, const char *certBuf, size_t buflen)
 	// puts cert data into x509_Crt struct and returns number of failed parses
 	failures = mbedtls_x509_crt_parse(x509, certBuf, buflen); 
 	if (failures) {
-		prlog(PR_INFO, "Failed to parse cert as DER mbedtls err#%d, trying PEM..\n", failures);
+		prlog(PR_INFO, "Failed to parse cert as DER mbedtls err#%d, trying PEM...\n", failures);
 		// if failed, maybe input is PEM and so try converting PEM to DER, if conversion fails then we know it was DER and it failed
 		if (convert_pem_to_der(certBuf, buflen, (unsigned char **) &generatedDER, &generatedDERSize)) {
-			prlog(PR_ERR, "\tParsing x509 from DER format failed mbedtls err#%d \n", failures);
+			prlog(PR_ERR, "Parsing x509 as PEM format failed mbedtls err#%d \n", failures);
 			return CERT_FAIL;
 		}
 		// if success then try to parse into x509 struct again
 		failures = mbedtls_x509_crt_parse(x509, generatedDER, generatedDERSize); 
 		if (failures) {
-			prlog(PR_ERR, "\tParsing x509 from PEM failed with MBEDTLS exit code: %d \n", failures);
+			prlog(PR_ERR, "Parsing x509 from PEM failed with MBEDTLS exit code: %d \n", failures);
 			return CERT_FAIL;
 		}
 	}

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -236,7 +236,7 @@ int validateAuth(const char *authBuf, size_t buflen, const char *key)
 	// now validate appended ESL 
 	// if no ESL appended then print warning and continue, could be a delete key update
 	if (authSize == buflen) {
-		prlog(PR_WARNING, "WARNING: appended ESL is empty...\n");
+		prlog(PR_WARNING, "WARNING: appended ESL is empty, (valid key reset file)...\n");
 	}
 	else {
 		rc = validateESL(authBuf + authSize, buflen - authSize, key);

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -13,7 +13,7 @@
 #define CERT_BUFFER_SIZE        2048
 
 #ifndef SECVARPATH
-#define SECVARPATH "/sys/firmware/secvar/vars"
+#define SECVARPATH "/sys/firmware/secvar/vars/"
 #endif
 
 #define variables  (char* []){ "PK", "KEK", "db", "dbx", "TS" }

--- a/include/err.h
+++ b/include/err.h
@@ -12,6 +12,7 @@ enum errors{
 	FILE_WRITE_FAIL = -8,
 	INVALID_TIMESTAMP = -9,
 	HASH_FAIL = -10,
-	ALLOC_FAIL = -11
+	ALLOC_FAIL = -11,
+	UNKNOWN_COMMAND = -12
 };
 #endif

--- a/secvarctl.1
+++ b/secvarctl.1
@@ -41,6 +41,9 @@ Commands are:
 .PP
 .B secvarctl generate
 <inputFormat>:<outputFormat> [OPTIONS] -i <inputFile> -o <outputFile>
+.PP
+.B secvarctl generate reset 
+[OPTIONS] -o <outputFile> -k <key> -c <crt> -n <variable>
 
 .SH DESCRIPTION
 .B secvarctl
@@ -157,7 +160,7 @@ option will give more process information.
 with no spaces between the colon and the format types. 
 The accepted values for <inputFormat> are:
 .RS
-[h]ash , A file containing only hashed data, use -h <hashAlg> to specifify the hash function used (default SHA256) 
+ [h]ash , A file containing only hashed data, use -h <hashAlg> to specifify the hash function used (default SHA256) 
  [c]ert , An x509 certificate (PEM), RSA2048 and SHA256 ONLY
  [e]sl , An EFI Signature List
  [p]kcs7 , a PKCS7 file containing signed data
@@ -166,7 +169,7 @@ The accepted values for <inputFormat> are:
 .RE
 The accepted values for <outputFormat> are:
 .RS
-[h]ash , A file containing only hashed data, use -h <hashAlg> to specifify the hash function used (default SHA256) 
+ [h]ash , A file containing only hashed data, use -h <hashAlg> to specifify the hash function used (default SHA256) 
  [e]sl , An EFI Signature List
  [p]kcs7 , a PKCS7 file containing signed data, must specify public and private keys and digest algorithm (default SHA256) (EXPERIMENTAL!)
  [a]uth , A signed authenticated file containing a PKCS7 and the new data, must specify public and private keys, digest algorithm (default SHA256) and secure variable name (EXPERIMENTAL!)
@@ -191,6 +194,13 @@ dbx) because then the prevalidation will look for an ESL containing a hash rathe
 .B -t 
 <time> , where <time> is in the format "y-m-d h:m:s". If this argument is not used then the current date and time are used.
  When using the input type '[f]ile' it will be assumed to be a text file and if output file is '[e]sl', '[p]kcs7' or '[a]uth' it will be hashed according to <hashAlg> (default SHA256).
+ To make a variable reset file, the user can replace
+.B generate <inputFormat>:<outputFormat> 
+with
+.B generate reset
+This will generate an auth file around an empty ESL. Thus, no input argument 
+.B -i 
+is required when making a reset file. 
   NOTE: GENERATION OF PKCS7 AND AUTH FILES ARE IN EXPERIMENTAL DEVELEPOMENT PHASE. THEY HAVE NOT BEEN THOROUGHLY TESTED YET.
 
 .RE
@@ -362,13 +372,18 @@ OPTIONAL:
 <time> , where time is of the format 'y-m-d h:m:s'. creates a custom timestamp used when generating an auth or PKCS7 file, if not given then current time is used
 .PP
 .B -h 
-<hashAlg> hash function, used when output or input format is hash, current values for <hashAlg> are : {'SHA256', 'SHA224', 'SHA1', 'SHA384', 'SHA512'}
+<hashAlg> , hash function, used when output or input format is hash, current values for <hashAlg> are : {'SHA256', 'SHA224', 'SHA1', 'SHA384', 'SHA512'}
 .PP
 .B -k 
 <privKey> , private key, used when generating pkcs7 or auth file
 .PP
 .B -c 
 <certFile> , x509 certificate (PEM), used when generating pkcs7 or auth file
+.PP
+.B reset 
+, replaces
+.B <inputFormat>:<outputFormat>
+and generates an auth file with an empty ESL (a valid variable reset file), no input file required. Required arguments are output file, signer public and private key and variable name.
 .RE
 .RE
 .SH EXAMPLES
@@ -419,8 +434,7 @@ To create a PKCS7 file from an ESL for a db update with a custom timestamp:
       $secvarctl generate e:p -k signer.key -c signer.crt -n db -t 2020-10-1 13:45:42 -i file.crt -o file.pkcs7 
 .PP
 To create a empty update to reset the db variable:
-      $touch empty.esl
-      $secvarctl generate e:a -k signer.key -c signer.crt -n db -f -i empty.esl -o db.auth 
+      $secvarctl generate reset -k signer.key -c signer.crt -n db -o db.auth 
 
 .SH AUTHOR
 Nick Child nick.child@ibm.com,

--- a/secvarctl.c
+++ b/secvarctl.c
@@ -88,16 +88,17 @@ int main(int argc, char *argv[])
 	subcommand = *argv; 
 	argv++;
 	argc--;
+
+	rc = UNKNOWN_COMMAND;
 	for (i = 0; i < backend->countCmds; i++) {
 		if (!strncmp(subcommand, backend->commands[i].name, 32)) {
 			rc = backend->commands[i].func(argc, argv);
 			break;
 		}
-		else if (i == backend->countCmds - 1) {
-			prlog(PR_ERR, "ERROR: unknown command %s\n", subcommand);
-			usage();
-			return ARG_PARSE_FAIL;
-		}
+	}
+	if (rc == UNKNOWN_COMMAND) {
+		prlog(PR_ERR, "ERROR:Unknown command %s\n", subcommand);
+		usage();
 	}
 	
 	return rc;

--- a/test/Makefile
+++ b/test/Makefile
@@ -3,12 +3,25 @@ py = python3
 # efitools = ../../efitools/
 efitools =../../efitools/
 data = testdata/PK_by_PK.auth
+
+#use STATIC=1 for static build
+MEMCHECK = 0
+ifeq ($(MEMCHECK),1)
+	MEMARGS = "MEMCHECK"
+else 
+	MEMARGS=
+endif
+
 all: $(data) ../secvarctl-cov
-	$(py) runTests.py
-	$(py) runSvcGenerateTests.py
+	$(py) runTests.py $(MEMARGS)
+	$(py) runSvcGenerateTests.py $(MEMARGS)
+	
+
 $(data): generateTestData.py
 	$(py) generateTestData.py $(efitools)
+
 ../secvarctl-cov:
 	make -C ../ secvarctl-cov
+
 clean:
 	rm -f -r ./*.txt generatedTestData testenv/*

--- a/test/runTests.py
+++ b/test/runTests.py
@@ -24,7 +24,6 @@ secvarctlCommands=[
 [["foobar"], False]#bad command
 ]
 ppcSecVarsRead=[
-[["-p","6", "read"], True], #print log correct
 [["read"], True],
 [["read", "-v"], True], [["read", "-r"], True], #verbose and raw
 [["read", "badVarname"], False], #bad var name

--- a/test/runTests.py
+++ b/test/runTests.py
@@ -290,7 +290,7 @@ class Test(unittest.TestCase):
 				preUpdate = "./testdata/empty.esl"
 			else:
 				preUpdate=file[:-4]+"esl"#get esl in auth
-			postUpdate="testGenerated.esl" #./testenv/<varname>/update
+			postUpdate="testGenerated.esl" 
 			if file.startswith("./testdata/dbx"):
 				self.assertEqual( getCmdResult(cmd+[ "-n",  "dbx", "-i", file, "-o", postUpdate],out, self), True)#assert command runs
 			else:
@@ -300,7 +300,7 @@ class Test(unittest.TestCase):
 		for i in toeslCommands:
 			self.assertEqual( getCmdResult(cmd+i[0],out, self),i[1])
 		for i in brokenAuths:
-			postUpdate="testGenerated.esl" #./testenv/<varname>/update
+			postUpdate="testGenerated.esl" 
 			self.assertEqual( getCmdResult(cmd+["-i", i, "-o", postUpdate],out, self), False) #all broken auths should fail to have correct esl
 			self.assertEqual( getCmdResult(["rm",postUpdate],out, self), False) #removal of output file should fail since it was never made
 	def test_badenv(self):


### PR DESCRIPTION
This PR is to update minor bugs and minor enhancements. These include:
  -Fixing a typo of the default path to secure variables 
  -Edited compiler optimization from -Os to -O2 because -Os was causing issues on ppc (opened a gcc bug report [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98692))
  -Allow for custom man page destination during install with `make install MANDIR=<path>`

I also created an easy way to generate key reset files with `secvarctl generate reset -n <varName> -k <signerKey> -c <signerCrt>`
This update has been reflected in documentation.