### PR TITLE
Add Cmake Build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,94 @@
+cmake_minimum_required( VERSION 3.12 )
+project( secvarctl C )
+
+set( CMAKE_C_COMPILER gcc )
+#sources/dependencies for secvarctl
+set( DEPEN secvarctl.h prlog.h err.h generic.h )
+set( DEPDIR include/ )
+list( TRANSFORM DEPEN PREPEND ${DEPDIR} )
+set( SRC secvarctl.c generic.c )
+
+#sources/dependencies for edk2 backend
+set( SKIBOOTDEPEN list.h config.h container_of.h check_type.h secvar.h opal-api.h endian.h short_types.h edk2.h edk2-svc.h )
+set( SKIBOOTDEPDIR backends/edk2-compat/include/ )
+list( TRANSFORM SKIBOOTDEPEN PREPEND ${SKIBOOTDEPDIR} )
+set ( SKIBOOTSRC secvar_util.c edk2-svc-read.c edk2-svc-write.c edk2-svc-validate.c edk2-compat.c edk2-compat-process.c   edk2-svc-verify.c edk2-svc-generate.c )
+set ( SKIBOOTSRCDIR backends/edk2-compat/ )
+list( TRANSFORM SKIBOOTSRC PREPEND ${SKIBOOTSRCDIR} )
+list( APPEND DEPEN ${SKIBOOTDEP} )
+list( APPEND SRC ${SKIBOOTSRC} )
+
+#sources/dependencies for extra mbedtls functions
+set( EXTRAMBEDTLSDEP generate-pkcs7.h pkcs7.h )
+set( EXTRAMBEDTLSDEPDIR extraMbedtls/include/ )
+list( TRANSFORM EXTRAMBEDTLSDEP PREPEND ${EXTRAMBEDTLSDEPDIR} )
+set ( EXTRAMBEDTLSSRC generate-pkcs7.c pkcs7.c )
+set ( EXTRAMBEDTLSSRCDIR  extraMbedtls/ )
+list( TRANSFORM EXTRAMBEDTLSSRC PREPEND ${EXTRAMBEDTLSSRCDIR} )
+list( APPEND DEPEN ${EXTRAMBEDTLSDEP} )
+list( APPEND SRC ${EXTRAMBEDTLSSRC} )
+
+add_executable( secvarctl ${SRC} )
+
+
+#User specified options 
+option( STATIC "Create statically linked executable" OFF )
+if ( STATIC )
+  set( BUILD_SHARED_LIBRARIES OFF )
+  set( CMAKE_EXE_LINKER_FLAGS "-static" )
+  set( PTHREAD "pthread" )
+endif(  )
+
+#Strip resulting executable for minimal size
+option( STRIP "Strip executable of extra data for minimal size" OFF )
+if ( STRIP )
+  set( BUILD_SHARED_LIBRARIES OFF )
+  string( APPEND CMAKE_C_FLAGS "-s" )
+endif(  )
+
+#no crypto means don't compile the generate command = smaller executable
+option( NO_CRYPTO "Build without crypto functions for smaller executable, some functionality lost" OFF )
+if ( NO_CRYPTO )
+  target_compile_definitions( secvarctl PRIVATE  NO_CRYPTO )
+endif(  )
+
+#append possible extensions for library
+LIST( APPEND CMAKE_FIND_LIBRARY_SUFFIXES ".so.0" ".a" ".so" )
+
+#get mbedtls if custom path defined
+if ( DEFINED CUSTOM_MBEDTLS )
+    find_library( MBEDX509 mbedx509 PATHS ${CUSTOM_MBEDTLS}/library NO_DEFAULT_PATH REQUIRED )
+    find_library( MBEDCRYPTO mbedcrypto PATHS ${CUSTOM_MBEDTLS}/library NO_DEFAULT_PATH REQUIRED )
+    find_library( MBEDTLS mbedtls PATHS ${CUSTOM_MBEDTLS}/library NO_DEFAULT_PATH REQUIRED )
+    include_directories( ${CUSTOM_MBEDTLS}/include )
+ 
+else(  )
+    find_library( MBEDX509 mbedx509 HINTS ENV PATH REQUIRED )
+    find_library( MBEDCRYPTO mbedcrypto HINTS ENV PATH REQUIRED )
+    find_library( MBEDTLS mbedtls HINTS ENV PATH REQUIRED )
+endif (  )
+target_link_libraries( secvarctl ${MBEDTLS} ${MBEDX509} ${MBEDCRYPTO} ${PTHREAD} ) 
+
+#set default build type to release
+set( DEFAULT_BUILD_TYPE "Release" )
+if ( NOT CMAKE_BUILD_TYPE )
+  set( CMAKE_BUILD_TYPE ${DEFAULT_BUILD_TYPE} )
+    message( "Setting build type to default: " ${CMAKE_BUILD_TYPE} )
+endif(  )
+#allow for different optimizations here
+set( CMAKE_C_FLAGS_RELEASE     "-O2 -g" )
+set( CMAKE_C_FLAGS_DEBUG       "-O0 -g3" )
+set( CMAKE_C_FLAGS_COVERAGE    "-O0 -g3 -fprofile-arcs -ftest-coverage" )
+
+
+#add linker flags ( -lmbedtls -lmbedcrypto -lmbedx509 not needed since linked above )
+target_link_options( secvarctl PUBLIC -Wall -Werror )
+
+
+
+#set c standard
+set( CMAKE_C_STANDARD 99 )
+set( CMAKE_C_STANDARD_REQUIRED ON )
+
+install( FILES ${CMAKE_CURRENT_SOURCE_DIR}/secvarctl.1 DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man1 )
+install( TARGETS secvarctl DESTINATION bin )

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 #_*_MakeFile_*_
 CC = gcc 
-_CFLAGS = -O2 -s -g -std=gnu99
+_CFLAGS = -s -O2 -std=gnu99
 LFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto -Wall -Werror 
 
 _DEPEN = secvarctl.h prlog.h err.h generic.h 
 DEPDIR = include
 DEPEN = $(patsubst %,$(DEPDIR)/%, $(_DEPEN))
-_SKIBOOT_DEPEN =list.h config.h container_of.h check_type.h secvar.h opal-api.h endian.h short_types.h edk2.h edk2-svc.h generate-pkcs7.h pkcs7.h
+_SKIBOOT_DEPEN =list.h config.h container_of.h check_type.h secvar.h opal-api.h endian.h short_types.h edk2.h edk2-svc.h 
 SKIBOOTDEPDIR = backends/edk2-compat/include
 SKIBOOTDEPEN = $(patsubst %,$(SKIBOOTDEPDIR)/%, $(_SKIBOOT_DEPEN))
+DEPEN += $(SKIBOOTDEPEN)
 
 _EXTRAMBEDTLS_DEPEN = pkcs7.h generate-pkcs7.h 
 EXTRAMBEDTLSDEPDIR = extraMbedtls/include
@@ -16,7 +17,7 @@ EXTRAMBEDTLSDEPEN = $(patsubst %,$(EXTRAMBEDTLSDEPDIR)/%, $(_EXTRAMBEDTLS_DEPEN)
 DEPEN += $(EXTRAMBEDTLSDEPEN)
 
 SKIBOOTOBJDIR = backends/edk2-compat
-_SKIBOOT_OBJ = secvar_util.o edk2-svc-read.o edk2-svc-write.o edk2-svc-validate.o edk2-compat.o edk2-compat-process.o   edk2-svc-verify.o
+_SKIBOOT_OBJ = secvar_util.o edk2-svc-read.o edk2-svc-write.o edk2-svc-validate.o edk2-compat.o edk2-compat-process.o   edk2-svc-verify.o edk2-svc-generate.o
 SKIBOOT_OBJ = $(patsubst %,$(SKIBOOTOBJDIR)/%, $(_SKIBOOT_OBJ))
 
 EXTRAMBEDTLSDIR = extraMbedtls

--- a/README.md
+++ b/README.md
@@ -26,10 +26,16 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
 	
 
 ## BUILDING:  
-  `$ git clone https://github.com/nick-child-ibm/secvarctl.git `   
-  `$ make `  
-  OR For Static Build:
-  `$ make STATIC=1`  
+ |               | Make      | CMake |
+ ---             | ----------- | ----------- |
+ | Build  | `make [build options]`      | `mdkir build && cd build && cmake [build options] ../ . && cmake --build .`      |
+ | Static Build | `STATIC=1` | `-DSTATIC=1`|
+ | Reduced Size Build | default | `-DSTRIP=1` |
+ | Build Without Crypto Functions | `NO_CRYPTO=1` | `-DNO_CRYPTO=1` |
+ | Build W Specific Mbedtls Library | `CFLAGS="-L<path>/library -I<path>/include"` | `-DCUSTOM_MBEDTLS=<path>` |
+ | Build for Coverage Tests | `make [options] secvarctl-cov` | `-DCMAKE_BUILD_TYPE=Coverage` |
+ | Install    | `make install`        | `cmake --install .`|
+ 
 
   
 ## FILE/KEY GENERATION:   

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -194,8 +194,8 @@ static int readFileFromSecVar(const char *path, const char *variable, int hrFlag
 		return ALLOC_FAIL;
 	}
 
-	strncpy(fullPath, path, strlen(path) + 1);
-	strncat(fullPath, variable, strlen(variable));
+	strcpy(fullPath, path);
+	strcat(fullPath, variable);
 	strcat(fullPath, "/data");
 
 	rc = getSecVar(&var, variable, fullPath);
@@ -276,16 +276,16 @@ int getSecVar(struct secvar **var, const char* name, const char *fullPath){
 	if (rc) {
 		return rc;
 	}
-	sizePath = malloc(strlen(fullPath) + 1);
+	sizePath = malloc( strlen(fullPath) + 1);
 	if (!sizePath) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 		return ALLOC_FAIL;
 	}
 	// since we are reading from a secvar, it can be assumed it has a <var>/size file for more accurate size
 	// fullPath currently holds <path>/<var>/data we are going to take off data and add size to get the desired file
-	strncpy(sizePath, fullPath, strlen(fullPath) - strlen("data"));
+	strcpy(sizePath, fullPath);
 	//add null terminator so strncat works
-	sizePath[strlen(fullPath) - strlen("data")] = '\0';
+	sizePath[strlen(sizePath) - strlen("data")] = '\0';
 	strncat(sizePath, "size", strlen("size") + 1); 
 	rc = getSizeFromSizeFile(&size, sizePath);
 	if (rc < 0) {

--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -480,7 +480,7 @@ static int getCurrentVars(char *newCurr[], int *size, const char* path)
 			prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 			return ALLOC_FAIL;
 		}
-		strncpy(fullPath, path, strlen(path));
+		strcpy(fullPath, path);
 		offset += strlen(path);
 		strncpy(fullPath + offset, variables[i], strlen(variables[i]));
 		offset += strlen(variables[i]);
@@ -501,7 +501,7 @@ static int getCurrentVars(char *newCurr[], int *size, const char* path)
 				return ALLOC_FAIL;
 			}
 
-			strncpy(newCurr[lenCtr++],fullPath, strlen(fullPath)+1);
+			strcpy(newCurr[lenCtr++],fullPath);
 		}
 		offset = 0;
 		free(fullPath);

--- a/backends/edk2-compat/edk2-svc-write.c
+++ b/backends/edk2-compat/edk2-svc-write.c
@@ -220,7 +220,7 @@ int updateVar(const char *path, const char *var, const char *buff, size_t size)
 		return ALLOC_FAIL;
 	}
 
-	strncpy(fullPathWithCommand, path, strlen(path) + 1);
+	strcpy(fullPathWithCommand, path);
 	strcat(fullPathWithCommand, var);
 	strcat(fullPathWithCommand, "/update");
 


### PR DESCRIPTION
This PR will allow for secvarctl to be made with CMake and Make. Previously, only Make was supported,  since the secvarctl tool has grown and is now being packaged for distros, it would be more beneficial to use an auto build tool like CMake. This PR will add the CMakeLists.txt file needed for CMake and the documentation in the README.md so users can compare the build process for Make and CMake. There is also a commit to better call strcpy that avoids errors during packaging for RHEL.