### PR TITLE
Enable -Wall and -Werror

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,8 +93,7 @@ set( CMAKE_C_FLAGS_DEBUG       "-O0 -g3" )
 set( CMAKE_C_FLAGS_COVERAGE    "-O0 -g3 -fprofile-arcs -ftest-coverage" )
 
 
-#add linker flags ( -lmbedtls -lmbedcrypto -lmbedx509 not needed since linked above )
-target_link_options( secvarctl PUBLIC -Wall -Werror )
+target_compile_options( secvarctl PRIVATE -Wall -Werror )
 
 
 

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 # Copyright 2021 IBM Corp.
 #_*_MakeFile_*_
 CC = gcc 
-_CFLAGS = -s -O2 -std=gnu99
-LFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto -Wall -Werror 
+_CFLAGS = -s -O2 -std=gnu99 -Wall -Werror
+LFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto
 
 _DEPEN = secvarctl.h prlog.h err.h generic.h 
 DEPDIR = include

--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -308,7 +308,7 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 {
 	int defaultVarsFlag = 0;
 	size_t len;
-	struct secvar *var, *tmp = NULL;
+	struct secvar *tmp = NULL;
 	char * c;
 	// check that update string given
 	if (!updateVars || updateCount <= 1) {
@@ -389,7 +389,7 @@ static int validateBanks(struct list_head *update_bank, struct list_head *variab
 			prlog(PR_ERR, "ERROR: Invalid variable %s, cannot update Timestamp variable\n", var->key);
 			return rc;
 		}
-		rc = validateAuth(var->data, var->data_size, var->key);
+		rc = validateAuth((unsigned char *)var->data, var->data_size, var->key);
 		if (rc) {
 			prlog(PR_ERR, "ERROR: failed to validate Auth file for %s, returned %d\n",var->key,rc);
 			return rc;
@@ -401,9 +401,9 @@ static int validateBanks(struct list_head *update_bank, struct list_head *variab
 		list_for_each(variable_bank, var, link) {
 			prlog(PR_INFO, "----VALIDATING CURRENT VAR: %s----\n", var->key);
 			if (strcmp(var->key, "TS") == 0) 
-				rc = validateTS(var->data, var->data_size);
+				rc = validateTS((unsigned char *)var->data, var->data_size);
 			else
-				rc = validateESL(var->data, var->data_size, var->key);
+				rc = validateESL((unsigned char *)var->data, var->data_size, var->key);
 			if (rc) {
 				prlog(PR_ERR, "ERROR: failed to validate data file for %s,returned %d\n", var->key, rc);
 				return rc;
@@ -544,7 +544,7 @@ static int commitUpdateBank(struct list_head *update_bank, const char *path)
 	struct secvar *var;
 	list_for_each(update_bank, var, link) {
 		prlog(PR_INFO, "Writing new %s with %zd bytes of data to %s%s/update\n",var->key, var->data_size, path, var->key);
-		rc = updateVar(path, var->key, var->data, var->data_size);
+		rc = updateVar(path, var->key, (unsigned char *)var->data, var->data_size);
 		if (rc) {
 			prlog(PR_ERR, "ERROR: issue writing to file #%d\n", rc); // consider continuing
 			return rc;

--- a/backends/edk2-compat/edk2-svc-write.c
+++ b/backends/edk2-compat/edk2-svc-write.c
@@ -164,7 +164,7 @@ int isVariable(const char * var)
 static int updateSecVar(const char *varName, const char *authFile, const char *path, int force)
 {	
 	int rc;
-	char *buff = NULL;
+	unsigned char *buff = NULL;
 	size_t size;
 
 	if (isVariable(varName)) {
@@ -183,7 +183,7 @@ static int updateSecVar(const char *varName, const char *authFile, const char *p
 	} 
 
 	// get data to write, if force flag then validate the data is an auth file
-	buff = getDataFromFile(authFile, &size); 
+	buff = (unsigned char *)getDataFromFile(authFile, &size); 
 	// if we are validating and validating fails, quit
 	if (!force) { 
 		rc = validateAuth(buff, size, varName);
@@ -210,7 +210,7 @@ static int updateSecVar(const char *varName, const char *authFile, const char *p
  *@param size , size of buff
  *@return whatever returned by writeData, SUCCESS or errno
  */
-int updateVar(const char *path, const char *var, const char *buff, size_t size)
+int updateVar(const char *path, const char *var, const unsigned char *buff, size_t size)
 {	
 	int commandLength, rc; 
 	char *fullPathWithCommand = NULL;
@@ -226,7 +226,7 @@ int updateVar(const char *path, const char *var, const char *buff, size_t size)
 	strcat(fullPathWithCommand, var);
 	strcat(fullPathWithCommand, "/update");
 
-	rc = writeData(fullPathWithCommand, buff, size);
+	rc = writeData(fullPathWithCommand, (const char *)buff, size);
 	free(fullPathWithCommand);
 
 	return rc;

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -50,27 +50,19 @@ void printGuidSig(const void *sig);
 EFI_SIGNATURE_LIST* get_esl_signature_list(const char *buf, size_t buflen);
 ssize_t get_esl_cert( const char *c,EFI_SIGNATURE_LIST *list ,char **cert);
 size_t get_pkcs7_len(const struct efi_variable_authentication_2 *auth);
-int parseX509(mbedtls_x509_crt *x509, const char *certBuf, size_t buflen);
+int parseX509(mbedtls_x509_crt *x509, const unsigned char *certBuf, size_t buflen);
 const char* getSigType(const uuid_t);
 
 int getSecVar(struct secvar **var, const char* name, const char *fullPath);
-int updateVar(const char* path, const char* var, const char* buff, size_t size);
+int updateVar(const char* path, const char* var, const unsigned char* buff, size_t size);
 int isVariable(const char *var);
 
-int validateAuth(const char *authBuf, size_t buflen, const char *key);
-int validateESL(const char *eslBuf, size_t buflen, const char *key);
-int validateCert(const char *authBuf, size_t buflen, const char *varName);
-int validatePKCS7(const char *cert_data, size_t len);
-int validateTS(const char *data, size_t size);
+int validateAuth(const unsigned char *authBuf, size_t buflen, const char *key);
+int validateESL(const unsigned char *eslBuf, size_t buflen, const char *key);
+int validateCert(const unsigned char *authBuf, size_t buflen, const char *varName);
+int validatePKCS7(const unsigned char *cert_data, size_t len);
+int validateTS(const unsigned char *data, size_t size);
 int validateTime(struct efi_time *time);
 
-static struct command edk2_compat_command_table[] = {
-	{ .name = "read", .func = performReadCommand },
-	{ .name = "write", .func = performWriteCommand },
-	{ .name = "validate", .func = performValidation },
-	{ .name = "verify", .func = performVerificationCommand },
-#ifndef NO_CRYPTO
-	{ .name = "generate", .func = performGenerateCommand }
-#endif
-};
+extern struct command edk2_compat_command_table[5];
 #endif

--- a/external/extraMbedtls/include/generate-pkcs7.h
+++ b/external/extraMbedtls/include/generate-pkcs7.h
@@ -1,10 +1,10 @@
 #ifndef GENERATE_PKCS7_H
 #define GENERATE_PKCS7_H
 #include "pkcs7.h"
-int to_pkcs7_already_signed_data(unsigned char **pkcs7, size_t *pkcs7Size, const char *newData, size_t newDataSize, 
+int to_pkcs7_already_signed_data(unsigned char **pkcs7, size_t *pkcs7Size, const unsigned char *newData, size_t newDataSize, 
     const char** crtFiles, const char** sigFiles,  int keyPairs, int hashFunct);
-int to_pkcs7_generate_signature(unsigned char **pkcs7, size_t *pkcs7Size, const char *newData, size_t newDataSize, 
+int to_pkcs7_generate_signature(unsigned char **pkcs7, size_t *pkcs7Size, const unsigned char *newData, size_t newDataSize, 
     const char** crtFiles, const char** keyFiles,  int keyPairs, int hashFunct);
 int convert_pem_to_der( const unsigned char *input, size_t ilen, unsigned char **output, size_t *olen );
-int toHash(const char* data, size_t size, int hashFunct, char** outHash, size_t* outHashSize);
+int toHash(const unsigned char* data, size_t size, int hashFunct, unsigned char** outHash, size_t* outHashSize);
 #endif

--- a/external/skiboot/edk2-compat-process.c
+++ b/external/skiboot/edk2-compat-process.c
@@ -219,7 +219,7 @@ static bool validate_cert(char *signing_cert, int signing_cert_size)
 	int rc;
 
 	mbedtls_x509_crt_init(&x509);
-	rc = mbedtls_x509_crt_parse(&x509, signing_cert, signing_cert_size);
+	rc = mbedtls_x509_crt_parse(&x509, (unsigned char *)signing_cert, signing_cert_size);
 
 	/* If failure in parsing the certificate, exit */
 	if(rc) {
@@ -519,7 +519,7 @@ static int verify_signature(const struct efi_variable_authentication_2 *auth,
 
 		mbedtls_x509_crt_init(&x509);
 		rc = mbedtls_x509_crt_parse(&x509,
-					    signing_cert,
+					    (unsigned char *)signing_cert,
 					    signing_cert_size);
 
 		/* This should not happen, unless something corrupted in PNOR */
@@ -546,7 +546,7 @@ static int verify_signature(const struct efi_variable_authentication_2 *auth,
 		free(x509_buf);
 		x509_buf = NULL;
 
-		rc = mbedtls_pkcs7_signed_hash_verify(pkcs7, &x509, newcert, new_data_size);
+		rc = mbedtls_pkcs7_signed_hash_verify(pkcs7, &x509, (unsigned char *)newcert, new_data_size);
 
 		/* If you find a signing certificate, you are done */
 		if (rc == 0) {
@@ -622,7 +622,7 @@ static char *get_hash_to_verify(const char *key, const char *new_data,
 	/* Expand char name to wide character width */
 	varlen = strlen(key) * 2;
 	wkey = char_to_wchar(key, strlen(key));
-	rc = mbedtls_md_update(&ctx, wkey, varlen);
+	rc = mbedtls_md_update(&ctx, (const unsigned char *)wkey, varlen);
 	free(wkey);
 	if (rc) 
 		goto out;
@@ -640,7 +640,7 @@ static char *get_hash_to_verify(const char *key, const char *new_data,
 	if (rc)
 		goto out;
 
-	rc = mbedtls_md_update(&ctx, new_data, new_data_size);
+	rc = mbedtls_md_update(&ctx, (const unsigned char *)new_data, new_data_size);
 	if (rc)
 		goto out;
 
@@ -655,7 +655,7 @@ static char *get_hash_to_verify(const char *key, const char *new_data,
 
 out:
 	mbedtls_md_free(&ctx);
-	return hash;
+	return (char *)hash;
 }
 
 bool is_pkcs7_sig_format(const void *data)

--- a/generic.c
+++ b/generic.c
@@ -71,6 +71,7 @@ char* getDataFromFile(const char* fullPath, size_t *size)
 	int fptr;
 	char *c = NULL;
 	struct stat fileInfo;
+	ssize_t read_size;
 	fptr = open(fullPath, O_RDONLY);			
 	if (fptr < 0) {
 		prlog(PR_WARNING,"----opening %s failed : %s----\n", fullPath, strerror(errno));
@@ -88,7 +89,13 @@ char* getDataFromFile(const char* fullPath, size_t *size)
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 		goto out;
 	}
-	read(fptr, c, fileInfo.st_size );
+	read_size = read(fptr, c, fileInfo.st_size);
+	if (read_size != fileInfo.st_size) {
+		prlog(PR_ERR, "ERROR: failed to read whole contents of %s in one go\n", fullPath);
+		free(c);
+		c = NULL;
+		goto out;
+	}
 	*size = fileInfo.st_size;
 out:	
 	close(fptr);

--- a/include/secvarctl.h
+++ b/include/secvarctl.h
@@ -13,12 +13,10 @@ enum backends {
 	EDK2_COMPAT
 };
 
-static struct backend {
+struct backend {
 	char name[32];
 	size_t countCmds;
 	struct command *commands;
-} backends [] = {
-	{ .name = "ibm,edk2-compat-v1", .countCmds = sizeof(edk2_compat_command_table) / sizeof(struct command), .commands = edk2_compat_command_table },
 };
 
 extern int verbose;

--- a/secvarctl.c
+++ b/secvarctl.c
@@ -9,8 +9,9 @@
 int verbose = PR_WARNING;
 static struct backend *getBackend();
 
-
-
+static struct backend backends [] = {
+	{ .name = "ibm,edk2-compat-v1", .countCmds = sizeof(edk2_compat_command_table) / sizeof(struct command), .commands = edk2_compat_command_table },
+};
 
 void usage() 
 {


### PR DESCRIPTION
They were being added in the link flags rather than the compile
flags, so they were not having any effect at all.

I've tried to propagate the `unsigned char` idiom from mbedtls outwards, but not into the skiboot parts just yet.

Signed-off-by: Daniel Axtens <dja@axtens.net>