### PR TITLE
CMakeLists.txt: change default build type to Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,18 +82,16 @@ endif (  )
 target_link_libraries( secvarctl ${MBEDTLS} ${MBEDX509} ${MBEDCRYPTO} ${PTHREAD} ) 
 
 #set default build type to release
-set( DEFAULT_BUILD_TYPE "Release" )
+set( DEFAULT_BUILD_TYPE "Debug" )
 if ( NOT CMAKE_BUILD_TYPE )
   set( CMAKE_BUILD_TYPE ${DEFAULT_BUILD_TYPE} )
     message( "Setting build type to default: " ${CMAKE_BUILD_TYPE} )
 endif(  )
 #allow for different optimizations here
 set( CMAKE_C_FLAGS_RELEASE     "-O2 -g" )
-set( CMAKE_C_FLAGS_DEBUG       "-O0 -g3" )
-set( CMAKE_C_FLAGS_COVERAGE    "-O0 -g3 -fprofile-arcs -ftest-coverage" )
+set( CMAKE_C_FLAGS_DEBUG       "-O0 -g3 -Wall -Werror" )
+set( CMAKE_C_FLAGS_COVERAGE    "-O0 -g3 -fprofile-arcs -ftest-coverage -Wall -Werror" )
 
-
-target_compile_options( secvarctl PRIVATE -Wall -Werror )
 
 
 


### PR DESCRIPTION
This commit will change the default build type to debug. Both debug and coverage have been given additional flags: -Wall and -Werror. The reasoning is that most of the time that the project is built from source, it will be to incorporate/test changes or enhancements. This will encourage all warnings to be fixed before commiting a change. If building for general use, then the Release build type can be used (these flags have not been added here for this reason)