### PR TITLE
Use argp for argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,15 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
 		-v , verbose, gives process info
 		-n <varName> , name of secure boot variable, used when generating an auth file, PKCS7, or when the input file contains hashed data rather than x509 (use '-n dbx'), current <varName> are: {'PK','KEK','db','dbx'}
 		-f force generation, skips validation of input file, assumes format to be correct
-		-t <time> , where time is of the format 'y-m-d h:m:s'. creates a custom timestamp used when generating an auth or PKCS7 file, if not given then current time is used
+		-t <time> , where <time> is of the format described below. creates a custom timestamp used when generating an auth or PKCS7 file, if not given then current time is used, all times are in UTC
+                    format of <time> = 'YYYY-MM-DDThh:mm:ss' where:
+                        - 'YYYY' four-digit year
+                        - 'MM' two-digit month (01=January, etc.)
+                        - 'DD' two-digit day of month (01 through 31)
+                        - 'T' appears literally
+                        - 'hh' two digits of hour (00 through 23) (am/pm NOT allowed)
+                        - 'mm' two digits of minute (00 through 59)
+                        - 'ss' two digits of second (00 through 59)
 		-h <hashAlg> hash function, used when output or input format is [h]ash, current <hashAlg> are : {'SHA256', 'SHA224', 'SHA1', 'SHA384', 'SHA512'}
 		-k <privKey> , private key, used when generating [p]kcs7 or [a]uth file
 		-c <certFile> , x509 certificate (PEM), used when generating [p]kcs7 or [a]uth file

--- a/backends/edk2-compat/edk2-svc-generate.c
+++ b/backends/edk2-compat/edk2-svc-generate.c
@@ -236,12 +236,20 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
             }
             args->pkcs7_gen_meth = W_PRIVATE_KEYS;
 			args->signKeyCount++;
-			args->signKeys = realloc(args->signKeys, args->signKeyCount * sizeof(char*));
+			rc = reallocArray((void **)&args->signKeys, args->signKeyCount, sizeof(*args->signKeys));
+			if (rc) {
+            	prlog(PR_ERR, "Failed to realloc private key (-k <>) array\n");
+            	break;
+            }
 			args->signKeys[args->signKeyCount - 1] = arg;
 			break;
 		case 'c':
 			args->signCertCount++;
-			args->signCerts = realloc(args->signCerts, args->signCertCount * sizeof(char*));
+			rc = reallocArray((void **)&args->signCerts, args->signCertCount, sizeof(*args->signCerts));
+			if (rc) {
+            	prlog(PR_ERR, "Failed to realloc certificate (-c <>) array\n");
+            	break;
+            }
 			args->signCerts[args->signCertCount - 1] = arg;
 			break;
 		case 'f':
@@ -259,7 +267,11 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
             }
             args->pkcs7_gen_meth = W_EXTERNAL_GEN_SIG;
             args->signKeyCount++;
-            args->signKeys = realloc(args->signKeys, args->signKeyCount * sizeof(char*));
+            rc = reallocArray((void **)&args->signKeys, args->signKeyCount, sizeof(*args->signKeys));
+            if (rc) {
+            	prlog(PR_ERR, "Failed to realloc signature (-s <>) array\n");
+            	break;
+            }
             args->signKeys[args->signKeyCount - 1] = arg;
 			break;
 		case 'i':

--- a/backends/edk2-compat/edk2-svc-generate.c
+++ b/backends/edk2-compat/edk2-svc-generate.c
@@ -85,6 +85,8 @@ int performGenerateCommand(int argc,char* argv[])
 		// these are hidden because they are mandatory and are described in the help message instead of in the options
 		{0, 'i', "FILE", OPTION_HIDDEN, "input file"},
 		{0, 'o', "FILE", OPTION_HIDDEN, "output file"},
+		{"help", '?', 0, 0, "Give this help list", 1},
+		{"usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{0}
 	};
 
@@ -131,7 +133,7 @@ int performGenerateCommand(int argc,char* argv[])
 
 	};
 
-	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER, 0, &args);
+	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag)
 		goto out;
 
@@ -206,24 +208,16 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 {
 	struct Arguments *args = state->input;
 	int rc = SUCCESS;
-	// this checks to see if help/usage is requested
-	// argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
-	// this becomes extra sticky since --usage/--help never actually get passed to this function
-	if (args->helpFlag == 0) {
-		if (state->next == 0 && state->next + 1 < state->argc) {
-			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next + 1], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next + 1], strlen("-?")) == 0)
-				args->helpFlag = 1;
-		}
-		else if (state->next < state->argc)
-			if (strncmp("--u", state->argv[state->next], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next], strlen("-?")) == 0)
-				args->helpFlag = 1;
-	}
 
 	switch (key) {
+		case '?':
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
+			break;
+		case ARGP_OPT_USAGE_KEY:
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_USAGE);
+			break;
 		case 'k':
 			 // if already storing signed data, then don't allow for private keys
             if (args->alreadySignedFlag == 1){

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -85,9 +85,9 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 {
 	struct Arguments *args = state->input;
 	int rc = SUCCESS;
-	//this checks to see if help/usage is requested
-	//argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
-	//this becomes extra sticky since --usage/--help never actually get passed to this function
+	// this checks to see if help/usage is requested
+	// argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
+	// this becomes extra sticky since --usage/--help never actually get passed to this function
 	if (args->helpFlag == 0) {
 		if (state->next == 0 && state->next + 1 < state->argc) {
 			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
@@ -285,7 +285,7 @@ int getSecVar(struct secvar **var, const char* name, const char *fullPath){
 	// since we are reading from a secvar, it can be assumed it has a <var>/size file for more accurate size
 	// fullPath currently holds <path>/<var>/data we are going to take off data and add size to get the desired file
 	strcpy(sizePath, fullPath);
-	//add null terminator so strncat works
+	// add null terminator so strncat works
 	sizePath[strlen(sizePath) - strlen("data")] = '\0';
 	strncat(sizePath, "size", strlen("size") + 1); 
 	rc = getSizeFromSizeFile(&size, sizePath);
@@ -434,7 +434,7 @@ static int printReadable(const char *c, size_t size, const char *key)
 	return SUCCESS;
 }
 
-//prints info on ESL, nothing on ESL data
+// prints info on ESL, nothing on ESL data
 void printESLInfo(EFI_SIGNATURE_LIST *sigList) 
 {
 	printf("\tESL SIG LIST SIZE: %d\n", sigList->SignatureListSize);
@@ -443,7 +443,7 @@ void printESLInfo(EFI_SIGNATURE_LIST *sigList)
 	printf("\tSignature type is: %s\n", getSigType(sigList->SignatureType));
 }
 
-//prints info on x509
+// prints info on x509
 int printCertInfo(mbedtls_x509_crt *x509)
 {
 	char *x509_info;
@@ -481,7 +481,7 @@ static int readTS(const char *data, size_t size)
 	}
 
 	for (tmpStamp = (struct efi_time *)data; size > 0; tmpStamp = (void *)tmpStamp + sizeof(struct efi_time), size -= sizeof(struct efi_time)) {
-		//print variable name
+		// print variable name
 		printf("\t%s:\t", variables[(ARRAY_SIZE(variables) - 1) - (size / sizeof(struct efi_time))]);
 		printTimestamp(*tmpStamp);
 	}
@@ -518,12 +518,12 @@ ssize_t get_esl_cert(const char *c, EFI_SIGNATURE_LIST *list , char **cert)
  */
 const char* getSigType(const uuid_t type) 
 {
-	//loop through all known hashes
+	// loop through all known hashes
 	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct); i++) {
 		if (uuid_equals(&type, hash_functions[i].guid)) 
 			return hash_functions[i].name;	
 	}
-	//try other known guids
+	// try other known guids
 	if (uuid_equals(&type, &EFI_CERT_X509_GUID)) return "X509";
 	else if (uuid_equals(&type, &EFI_CERT_RSA2048_GUID)) return "RSA2048";
 	else if (uuid_equals(&type, &EFI_CERT_TYPE_PKCS7_GUID))return "PKCS7";
@@ -605,8 +605,8 @@ static int getSizeFromSizeFile(size_t *returnSize, const char* path)
 	close(fptr);
 	// turn string into base 10 int
 	*returnSize = strtol(c, NULL, 0); 
-	//strol likes to return zero if there is no conversion from string to int
-	//so we need to differentiate an error from a file that actually contains 0
+	// strol likes to return zero if there is no conversion from string to int
+	// so we need to differentiate an error from a file that actually contains 0
 	if (*returnSize == 0 && c[0] != '0')
 		rc = INVALID_FILE;
 	else

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -53,6 +53,8 @@ int performReadCommand(int argc, char* argv[])
 		{"verbose", 'v', 0, 0, "print more verbose process information"},
 		{"file", 'f', "FILE", 0, "navigates to ESL file from working directiory"},
 		{"path", 'p', "PATH" ,0, "looks for key directories {'PK','KEK','db','dbx', 'TS'} in PATH, default is " SECVARPATH},
+        {"help", '?', 0, 0, "Give this help list", 1},
+		{"usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{0}
 	};
 
@@ -65,7 +67,7 @@ int performReadCommand(int argc, char* argv[])
 		" then the '-f' command would be appropriate."
 		"\vvalues for [VARIABLES] = {'PK','KEK','db','dbx', 'TS'} type one of the following to get info on that key, default is all. NOTE does not work when -f option is present"
 	};
-	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER, 0, &args);
+	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag)
 		goto out;
 
@@ -85,24 +87,16 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 {
 	struct Arguments *args = state->input;
 	int rc = SUCCESS;
-	// this checks to see if help/usage is requested
-	// argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
-	// this becomes extra sticky since --usage/--help never actually get passed to this function
-	if (args->helpFlag == 0) {
-		if (state->next == 0 && state->next + 1 < state->argc) {
-			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next + 1], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next + 1], strlen("-?")) == 0)
-				args->helpFlag = 1;
-		}
-		else if (state->next < state->argc)
-			if (strncmp("--u", state->argv[state->next], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next], strlen("-?")) == 0)
-				args->helpFlag = 1;
-	}
 
 	switch (key) {
+		case '?':
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
+			break;
+		case ARGP_OPT_USAGE_KEY:
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_USAGE);
+			break;
 		case 'r':
 			args->printRaw = 1;
 			break;

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -633,30 +633,34 @@ out:
 	return rc;
 }
 
-
+/*
+ *ensures that efi_time values are  in correct ranges
+ *@param time , pointer to an efi_time struct
+ *return SUCCESS or INVALID_TIMESTAMP if not valid
+ */
 int validateTime(struct efi_time *time) 
 {
-	if (time->year < 0 || time->year > 9999) {
+	if (time->year < 1900 || time->year > 9999) {
 		prlog(PR_ERR,"ERROR: Invalid Timestamp value for year: %d\n", time->year);
 		return INVALID_TIMESTAMP;
 	}
 	
-	if (time->month < 0 || time->month > 12){
+	if (time->month < 1 || time->month > 12){
 		prlog(PR_ERR,"ERROR: Invalid Timestamp value for month: %d\n", time->month );
 		return INVALID_TIMESTAMP;
 	}
 	
-	if (time->day < 0 || time->day > 31){
+	if (time->day < 1 || time->day > 31){
 		prlog(PR_ERR,"ERROR: Invalid Timestamp value for day: %d\n", time->day);
 		return INVALID_TIMESTAMP;
 	}
 		
-	if (time->hour < 0 || time->hour > 24){
+	if (time->hour < 0 || time->hour > 23){
 		prlog(PR_ERR,"ERROR: Invalid Timestamp value for hour: %d\n", time->hour);
 		return INVALID_TIMESTAMP;
 	}
 		
-	if (time->minute < 0 || time->minute > 60){
+	if (time->minute < 0 || time->minute > 59){
 		prlog(PR_ERR,"ERROR: Invalid Timestamp value for minute: %d\n", time->minute);
 		return INVALID_TIMESTAMP;
 	}
@@ -673,5 +677,5 @@ void printTimestamp(struct efi_time t)
 {
 	// NOTE: if auth is made with sign-efi-sig-list, year will be actual year+1 (see https:// blog.hansenpartnership.com/updating-pk-kek-db-and-x-in-user-mode/), 
 	// also month could be one less bc months are 0-11 not 1-12
-	printf("%04d-%02d-%02d %02d:%02d:%02d\n", t.year,t.month,t.day, t.hour, t.minute, t.second); 
+	printf("%04d-%02d-%02d %02d:%02d:%02d UTC\n", t.year,t.month,t.day, t.hour, t.minute, t.second); 
 }

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -112,9 +112,9 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 {
 	struct Arguments *args = state->input;
 	int rc = SUCCESS;
-	//this checks to see if help/usage is requested
-	//argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
-	//this becomes extra sticky since --usage/--help never actually get passed to this function (and neither does argv  [0])
+	// this checks to see if help/usage is requested
+	// argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
+	// this becomes extra sticky since --usage/--help never actually get passed to this function (and neither does argv  [0])
 	if (args->helpFlag == 0) {
 		if (state->next == 0 && state->next + 1 < state->argc) {
 			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
@@ -154,7 +154,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 				args->inFile = arg;
 			break;
 		case ARGP_KEY_SUCCESS:
-			//check that all essential args are given and valid
+			// check that all essential args are given and valid
 			if (args->helpFlag)
 				break;
 			if (!args->inFile) 
@@ -458,7 +458,7 @@ static int validateSingularESL(size_t* bytesRead, const unsigned char* esl, size
 // from edk2-compat-process.c
 static bool validate_hash(uuid_t type, size_t size)
 {
-	//loop through all known hashes
+	// loop through all known hashes
 	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct); i++) {
         if (uuid_equals(&type, hash_functions[i].guid) && (size == hash_functions[i].size))
             return true;
@@ -526,8 +526,8 @@ int validateCert(const unsigned char *certBuf, size_t buflen, const char *varNam
 		goto out;
 	}
 	
-	//if x509 for db then signature can be RSA 4096 or other (since it won't be signing anything else)
-	//this addresses OS's that release certificates with non RSA-2048 (ex: RHEL)
+	// if x509 for db then signature can be RSA 4096 or other (since it won't be signing anything else)
+	// this addresses OS's that release certificates with non RSA-2048 (ex: RHEL)
 	if (varName == NULL || strncmp(varName, "db", strlen(varName))) {
 		if ( x509->sig_md != MBEDTLS_MD_SHA256 
 		|| strncmp((const char *)x509->sig_oid.p, MBEDTLS_OID_PKCS1_SHA256, x509->sig_oid.len) 

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -54,6 +54,8 @@ int performValidation(int argc, char* argv[])
 		{"cert", 'c', 0 ,0, "file is an x509 cert (DER or PEM format)"},
 		{"auth", 'a', 0, 0, "file is a properly generated authenticated variable, DEFAULT"},
 		{"dbx", 'x', 0, 0, "file is for the dbx (allows for data to contain a hash not an x509), Note: user still should specify the file type"},
+		{"help", '?', 0, 0, "Give this help list", 1},
+		{"usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{0}
 	};
 
@@ -64,7 +66,7 @@ int performValidation(int argc, char* argv[])
 		" use 'secvarctl verify' to see if content and file signature (if PKCS7/auth) are valid"
 	};
 
-	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER, 0, &args);
+	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag)
 		goto out;
 	
@@ -112,24 +114,16 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 {
 	struct Arguments *args = state->input;
 	int rc = SUCCESS;
-	// this checks to see if help/usage is requested
-	// argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
-	// this becomes extra sticky since --usage/--help never actually get passed to this function (and neither does argv  [0])
-	if (args->helpFlag == 0) {
-		if (state->next == 0 && state->next + 1 < state->argc) {
-			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next + 1], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next + 1], strlen("-?")) == 0)
-				args->helpFlag = 1;
-		}
-		else if (state->next < state->argc)
-			if (strncmp("--u", state->argv[state->next], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next], strlen("-?")) == 0)
-				args->helpFlag = 1;
-	}
 
 	switch (key) {
+		case '?':
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
+			break;
+		case ARGP_OPT_USAGE_KEY:
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_USAGE);
+			break;
 		case 'v': 
 			verbose = PR_DEBUG; 
 			break;

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -96,7 +96,7 @@ static void usage() {
 		"\n\t\t-v\t\tverbose, print process info"
 		"\n\t\t-x\t\tfile is for the dbx, allows data to be a hash not an x509,\n\t"
 		"\t\t\tNOTE: user still needs to specify file type"
-		"\n\t\t-p\t\tfile is a PKCS7\n\t\t-e\t\tfile is an ESL\n\t\t-a\t\tfile is an auth"
+		"\n\t\t-p\t\tfile is a PKCS7\n\t\t-e\t\tfile is an ESL"
 		"\n\t\t-c\t\tfile is a x509 cert (DER or PEM format)"
 		"\n\t\t-a\t\tfile is a signed authenticated file containg a PKCS7 and appended ESL\n\t"
 		"\t\t\tDEFAULT\n");

--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -4,7 +4,8 @@
 #include <string.h>
 #include <stdlib.h>// for exit
 #include <fcntl.h> // O_RDONLY
-#include <unistd.h> // has read/open funcitons
+#include <unistd.h> // has read/open functions
+#include <argp.h>
 #include "../../external/skiboot/include/opal-api.h"
 #include "../../external/skiboot/include/secvar.h"
 #include "include/edk2-svc.h"
@@ -19,14 +20,11 @@ struct Arguments {
 
 extern struct secvar_backend_driver edk2_compatible_v1;
 
-
-static void usage();
-static void help();
 static int verify(char **currentVars, int currCount, const char **updateVars, int updateCount, const char *path, int writeFlag);
 static int validateVarsArg(const char *vars[], int size);
 static int getCurrentVars(char **newCurr, int *size, const char *path);
 static char *opalErrToString(int rc);
-static int parseArgs(int argc, char *argv[], struct Arguments *args);
+static int parse_opt(int key, char *arg, struct argp_state *state);
 static int validateBanks(struct list_head *update_bank, struct list_head *variable_bank);
 static int setupBanks(struct list_head *variable_bank, struct list_head *update_bank, char *currentVars[], int currCount, const char *updateVars[], int updateCount, const char*path);
 static void printBanks(struct list_head *variable_bank, struct list_head *update_bank);
@@ -45,183 +43,166 @@ int performVerificationCommand(int argc, char* argv[])
 		.helpFlag = 0, .writeFlag = 0, .currVarCount = 0, .updateVarCount = 0,
 		.pathToSecVars = NULL, .updateVars = NULL, .currentVars = 0
 	};
+    // combine command and subcommand for usage/help messages
+	argv[0] = "secvarctl verify";
 
-	rc = parseArgs(argc, argv, &args);
+	struct argp_option options[] = 
+	{
+		{"verbose", 'v', 0, 0, "print more verbose process information"},
+		{"path", 'p', "PATH" ,0, "manually set path to current variables, looks for .../<var>/data file in PATH, default is " SECVARPATH " . Cannot be used with `-c` "},
+		{"current", 'c', "{CURRENT VAR LIST}", 0, "manually set current vars to be contents of CURRENT VAR LIST (see below for format)"},
+		{"write", 'w', 0, 0, "if successful, submit the update to be commited upon reboot. Equivalent to `secvarctl write`"},
+		{0, 'u', "{UPDATE LIST}", OPTION_HIDDEN, "set update variables (see below for format)"},
+		{0}
+	};
+
+	struct argp argp = {
+		options, parse_opt, "-u {UPDATE LIST}", 
+		"This command ensures that the proposed variable updates are"
+		" correctly signed by the current variables. If successful, then the user can run the same"
+		" command with the '-w' flag or use 'secvarctl write' to submit the updates to be"
+		" committed upon reboot\v"
+		"UPDATE LIST:\nAt least one variable-file pair is required. Formatted as:"
+		" ' -u <varName_1> <authFileForVar_1> <varName_2> <authFileForVar_2> ... '"
+		" Where <varName> is one of {'PK','KEK','db','dbx'}"
+		" and <authFileForVar> is a properly generated authenticated variable file that is"
+		" signed by a current variable with priviledges to approve the update\n\n"
+		"CURRENT_VAR_LIST:\nOptional, only used when -c is used. Formatted as:"
+		" ' -c <varName_1> <eslFileForVar_1> <varName_2> <eslFileForVar_2> ... '"
+		" Where <varName> is one of {'PK','KEK','db','dbx', 'TS'} and"
+		" <eslFileForVar> is an EFI Signature List."
+		" unless variable is TS (in which case it would contain 4 16 byte timestamps)"
+	};
+
+	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER, 0, &args);
 	if (rc || args.helpFlag) {
-		goto out;
-	}
-	if (args.currVarCount && args.writeFlag) {
-		prlog(PR_ERR, "ERROR: Cannot update files if current variable files are given. remove -w\n");
-		usage();
-		rc = ARG_PARSE_FAIL;
 		goto out;
 	}
 
 	rc = verify(args.currentVars, args.currVarCount, args.updateVars, args.updateVarCount, args.pathToSecVars, args.writeFlag);
 	
 out:
-	if (rc) 
-		printf("RESULT: FAILURE\n");
-	else 
-		printf("RESULT: SUCCESS\n");
 	if (args.currentVars) 
 		free(args.currentVars);
 	if (args.updateVars) 
 		free(args.updateVars);
+	if (!args.helpFlag) 
+		printf("RESULT: %s\n", rc ? "FAILURE" : "SUCCESS");
 	
 	return rc;
 }
 
 /**
- *@param argv , array of command line arguments
- *@param argc, length of argv
- *@param args, struct that will be filled with data from argv
+ *@param key , every option that is parsed has a value to identify it
+ *@param arg, if key is an option than arg will hold its value ex: -<key> <arg>
+ *@param state,  argp_state struct that contains useful information about the current parsing state 
  *@return success or errno
  */
-static int parseArgs( int argc, char *argv[], struct Arguments *args) {
-	int rc = SUCCESS;
-	for (int i = 0; i < argc; i++) {
-		if (argv[i][0] == '-') {
-			if (!strcmp(argv[i], "--usage")) {
-				usage();
+static int parse_opt(int key, char *arg, struct argp_state *state) 
+{
+	struct Arguments *args = state->input;
+	int current, rc = SUCCESS;
+	//this checks to see if help/usage is requested
+	//argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
+	//this becomes extra sticky since --usage/--help never actually get passed to this function
+	if (args->helpFlag == 0) {
+		if (state->next == 0 && state->next + 1 < state->argc) {
+			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
+				|| strncmp("--h", state->argv[state->next + 1], strlen("--h")) == 0
+				|| strncmp("-?", state->argv[state->next + 1], strlen("-?")) == 0)
 				args->helpFlag = 1;
-				goto out;
-			}
-			else if (!strcmp(argv[i], "--help")) {
-				help();
+		}
+		else if (state->next < state->argc)
+			if (strncmp("--u", state->argv[state->next], strlen("--u")) == 0 
+				|| strncmp("--h", state->argv[state->next], strlen("--h")) == 0
+				|| strncmp("-?", state->argv[state->next], strlen("-?")) == 0)
 				args->helpFlag = 1;
-				goto out;
+	}
+
+	switch (key) {
+		case 'p':
+			args->pathToSecVars = arg;
+			break;
+		case 'w':
+			args->writeFlag = 1;
+			break;
+		case 'v':
+			verbose = PR_DEBUG;
+			break;
+		case 'u':
+			if (args->updateVars) {
+				prlog(PR_ERR, "ERROR: Update variables defined twice, see usage...\n");
+				argp_usage(state);
+				rc = ARG_PARSE_FAIL;
+				break;
 			}
-			// set verbose flag
-			else if (!strcmp(argv[i], "-v")) {
-				verbose = PR_DEBUG; 
+			current = state ->next - 1;
+	        while(state->next != state->argc && state->argv[state->next][0] != '-')
+	            state->next++;
+	        args->updateVarCount = (state->next - current);
+	        args->updateVars = malloc(sizeof(char*) * args->updateVarCount);
+	        if (!args->updateVars) {
+	            prlog(PR_ERR, "ERROR: failed to allocate memory\n");
+	            rc = ALLOC_FAIL;
+	            break;
+	        }
+        	memcpy(args->updateVars, &state->argv[current], args->updateVarCount * sizeof(char*));	        
+	        break;
+		case 'c':
+			if (args->currentVars) {
+				prlog(PR_ERR, "ERROR: Current variables defined twice, see usage...\n");
+				argp_usage(state);
+				rc = ARG_PARSE_FAIL;
+				break;
 			}
-			
-			// set current vars
-			else if(!strcmp(argv[i], "-c")) {	
-				if (args->currentVars) {
-					prlog(PR_ERR, "ERROR: Current variables defined twice, see usage...\n");
-					rc = ARG_PARSE_FAIL;
-					goto out;
-				}
-				i++;
-				// until next option is approached, add argument to array
-				while (i < argc && argv[i][0] != '-') { 
-					args->currVarCount++;
-					i++;
-				}
-				if (args->currVarCount > 0) {
-					args->currentVars = malloc(sizeof(char*) * args->currVarCount);
-					if (!args->currentVars) {
-						prlog(PR_ERR, "ERROR: failed to allocate memory\n");
-						rc = ALLOC_FAIL;
-						goto out;
-					}
-					memcpy(args->currentVars, &argv[i - args->currVarCount], args->currVarCount * sizeof(char*));
-				}
-				// to iterate back to the -" " arg
-				i--;	
-				//make sure format was correct
-				if (validateVarsArg((const char **) args->currentVars, args->currVarCount)) {
+			current = state ->next - 1;
+	        while(state->next != state->argc && state->argv[state->next][0] != '-')
+	            state->next++;
+	        args->currVarCount = (state->next - current);
+	        args->currentVars = malloc(sizeof(char*) * args->currVarCount);
+	        if (!args->currentVars) {
+	            prlog(PR_ERR, "ERROR: failed to allocate memory\n");
+	            rc = ALLOC_FAIL;
+	            break;
+	        }
+        	memcpy(args->currentVars, &state->argv[current], args->currVarCount * sizeof(char*));
+        	break;
+		case ARGP_KEY_SUCCESS:
+			//check that all essential args are given and valid
+			if (args->helpFlag)
+				break;
+			if (!args->updateVarCount || args->updateVarCount <= 1)
+				prlog(PR_ERR, "ERROR: No update variables/files given, use -u <varName_1> <authFileForVar_1>...\n\t\t"
+					"Where <varName> is one of {'PK','KEK','db','dbx'} and <authFileForVar> is "
+					"a properly generated authenticated variable file\n");
+			else if (validateVarsArg(args->updateVars, args->updateVarCount)) 
+					prlog(PR_ERR,"ERROR: Update vars list not in right format: "
+					"-u <varName_1> <authFileForVar_1> <varName_2> <authFileForVar_2> ...\n\t\t"
+					"Where <varName> is one of {'PK','KEK','db','dbx'} and <authFileForVar> is "
+					"a properly generated authenticated variable file\n");
+			else if (args->currVarCount) {
+				if (args->writeFlag)
+					prlog(PR_ERR, "ERROR: Cannot update files if current variable files are given. remove -w\n");
+				else if (validateVarsArg((const char **) args->currentVars, args->currVarCount)) 
 					prlog(PR_ERR,"ERROR: Current vars list not in right format: "
 						"<varName_1> <eslFileForVar_1> <varName_2> <eslFileForVar_2> ...\n\t\t"
-						"Where <varName> is one of {'PK','KEK','db','dbx', 'TS'} and <eslFileForVar> is an EFI Signature List file (unless TS variable)\n");
-					rc = ARG_PARSE_FAIL;
-					goto out;
-				}
+						"Where <varName> is one of {'PK','KEK','db','dbx', 'TS'} and <eslFileForVar> is an"
+						" EFI Signature List file (unless TS variable)\n");
+				else 
+					break;
+			}		
+			else 
+				break;
+			argp_usage(state);
+			rc = ARG_PARSE_FAIL;
+			break;
+	}
 
-			}
-			// set updateVars array
-			else if (!strcmp(argv[i], "-u")) {	
-				if (args->updateVars) {
-					prlog(PR_ERR, "ERROR: Update variables defined twice, see usage...\n");
-					rc = ARG_PARSE_FAIL;
-					goto out;
-				}
-				i++;
-				while(i < argc && argv[i][0] != '-'){
-					args->updateVarCount++;
-					i++;
-				}
-				if (args->updateVarCount > 0) {
-					args->updateVars = malloc(sizeof(char*) * args->updateVarCount);
-					if (!args->updateVars) {
-						prlog(PR_ERR, "ERROR: failed to allocate memory\n");
-						rc = ALLOC_FAIL;
-						goto out;
-					}
-					memcpy(args->updateVars, &argv[i - args->updateVarCount], args->updateVarCount * sizeof(char*));
-				}
-				i--;
-				//make sure format was correct
-				if (validateVarsArg(args->updateVars, args->updateVarCount)) {
-					prlog(PR_ERR,"ERROR: Update vars list not in right format: "
-					"<varName_1> <authFileForVar_1> <varName_2> <authFileForVar_2> ...\n\t\t"
-					"Where <varName> is one of {'PK','KEK','db','dbx'} and <authFileForVar> is an authenticated file)\n");
-					rc = ARG_PARSE_FAIL;
-					goto out;
-				}
-			}
-			else if (!strcmp(argv[i], "-p")) {
-				if (i + 1 >= argc || argv[i + 1][0] == '-') {
-					prlog(PR_ERR, "ERROR: Incorrect value for '-p', see usage...\n");
-					rc = ARG_PARSE_FAIL;
-					goto out;
-				}
-				else {
-					i++;
-					args->pathToSecVars= argv[i];
-				}
-			}
-			else if (!strcmp(argv[i], "-w"))
-				args->writeFlag = 1;
-		}
-	}
-		
-out:
-	if (rc) {
+	if (rc) 
 		prlog(PR_ERR, "Failed during argument parsing\n");
-		usage();
-	}
 
 	return rc;
 }
-
-
-static void usage()
-{
-	printf( "USAGE:\n\t$ secvarctl verify [OPTIONS] -u {UPDATE LIST}\n"
-		"OPTIONS:\n"
-		"\t--help/--usage\n"
-		"\t-v\t\t\tverbose, give process progress\n"
-		"\t-w\t\t\twrite, if successful, submit the update to be commited upon reboot\n\t"
-		"-c {CURRENT VAR LIST}\tset current vars to be contents of CURRENT VAR LIST,\n"
-		"\t\t\t\tdefault is keys from " SECVARPATH "\n\t"
-		"-p <path to vars>\tlooks for key directories {'PK','KEK','db','dbx', 'TS'} in <path>\n"
-		"\t\t\t\tdefault is " SECVARPATH "\n"
-		"\t\t\t\tcannot be used with '-c'\n"
-		"CURRENT VAR LIST:\n\tOptional, only used when -c is used. Formatted as:"
-		"\n\t\t' -c <varName_1> <eslFileForVar_1> <varName_2> <eslFileForVar_2> ... '\n\t\t"
-		"Where <varName> is one of {'PK','KEK','db','dbx', 'TS'} and\n"
-		"\t\t<eslFileForVar> is an EFI Signature List containing an x509 certificate\n"
-		"\t\tunless variable is TS (in which case it would contain 4 16 byte timestamps)\n"
-		"UPDATE LIST:\n\tAt least one variable-file pair is required. Formatted as:"
-		"\n\t\t' -u <varName_1> <authFileForVar_1> <varName_2> <authFileForVar_2> ... '\n\t\t"
-		"Where <varName> is one of {'PK','KEK','db','dbx'} \n"
-		"\t\tand <authFileForVar> is an authenticated file signed by a current variable with\n" 
-		"\t\tprivileges to approve the update\n");
-}
-
-static void help()
-{
-	printf( "HELP:\n\t"
-		"The purpose of this command is to ensure that the proposed variable updates are \n"
-		"\tsigned by the current variables. If successful, then the user can run the same\n"
-		"\tcommand with the '-w' flag or use 'secvarctl write' to submit the updates to be \n"
-		"\tcommitted upon reboot\n");
-	usage();
-}
-
 
 /**
  *runs actual verification process
@@ -310,12 +291,7 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 	size_t len;
 	struct secvar *tmp = NULL;
 	char * c;
-	// check that update string given
-	if (!updateVars || updateCount <= 1) {
-		fprintf(stderr,"ERROR: No update vars given\n");
-		usage();
-		return ARG_PARSE_FAIL;
-	}	
+
 	// if current vars string is given, check it. if not, get default/path vars
 	if (!currentVars) { 
 		defaultVarsFlag = 1;

--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -53,6 +53,8 @@ int performVerificationCommand(int argc, char* argv[])
 		{"current", 'c', "{CURRENT VAR LIST}", 0, "manually set current vars to be contents of CURRENT VAR LIST (see below for format)"},
 		{"write", 'w', 0, 0, "if successful, submit the update to be commited upon reboot. Equivalent to `secvarctl write`"},
 		{0, 'u', "{UPDATE LIST}", OPTION_HIDDEN, "set update variables (see below for format)"},
+		{"help", '?', 0, 0, "Give this help list", 1},
+		{"usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{0}
 	};
 
@@ -74,7 +76,7 @@ int performVerificationCommand(int argc, char* argv[])
 		" unless variable is TS (in which case it would contain 4 16 byte timestamps)"
 	};
 
-	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER, 0, &args);
+	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag) {
 		goto out;
 	}
@@ -102,24 +104,16 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 {
 	struct Arguments *args = state->input;
 	int current, rc = SUCCESS;
-	// this checks to see if help/usage is requested
-	// argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
-	// this becomes extra sticky since --usage/--help never actually get passed to this function
-	if (args->helpFlag == 0) {
-		if (state->next == 0 && state->next + 1 < state->argc) {
-			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next + 1], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next + 1], strlen("-?")) == 0)
-				args->helpFlag = 1;
-		}
-		else if (state->next < state->argc)
-			if (strncmp("--u", state->argv[state->next], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next], strlen("-?")) == 0)
-				args->helpFlag = 1;
-	}
 
 	switch (key) {
+		case '?':
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
+			break;
+		case ARGP_OPT_USAGE_KEY:
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_USAGE);
+			break;
 		case 'p':
 			args->pathToSecVars = arg;
 			break;

--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -102,9 +102,9 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 {
 	struct Arguments *args = state->input;
 	int current, rc = SUCCESS;
-	//this checks to see if help/usage is requested
-	//argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
-	//this becomes extra sticky since --usage/--help never actually get passed to this function
+	// this checks to see if help/usage is requested
+	// argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
+	// this becomes extra sticky since --usage/--help never actually get passed to this function
 	if (args->helpFlag == 0) {
 		if (state->next == 0 && state->next + 1 < state->argc) {
 			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
@@ -168,7 +168,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
         	memcpy(args->currentVars, &state->argv[current], args->currVarCount * sizeof(char*));
         	break;
 		case ARGP_KEY_SUCCESS:
-			//check that all essential args are given and valid
+			// check that all essential args are given and valid
 			if (args->helpFlag)
 				break;
 			if (!args->updateVarCount || args->updateVarCount <= 1)

--- a/backends/edk2-compat/edk2-svc-write.c
+++ b/backends/edk2-compat/edk2-svc-write.c
@@ -78,9 +78,9 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 {
 	struct Arguments *args = state->input;
 	int rc = SUCCESS;
-	//this checks to see if help/usage is requested
-	//argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
-	//this becomes extra sticky since --usage/--help never actually get passed to this function
+	// this checks to see if help/usage is requested
+	// argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
+	// this becomes extra sticky since --usage/--help never actually get passed to this function
 	if (args->helpFlag == 0) {
 		if (state->next == 0 && state->next + 1 < state->argc) {
 			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
@@ -112,7 +112,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 				args->inFile = arg;
 			break;
 		case ARGP_KEY_SUCCESS:
-			//check that all essential args are given and valid
+			// check that all essential args are given and valid
 			if (args->helpFlag)
 				break;
 			if(!args->varName) 

--- a/backends/edk2-compat/edk2-svc-write.c
+++ b/backends/edk2-compat/edk2-svc-write.c
@@ -41,6 +41,8 @@ int performWriteCommand(int argc, char* argv[])
 		{"verbose", 'v', 0, 0, "print more verbose process information"},
 		{"force", 'f', 0, 0, "force update, skips validation of file"},
 		{"path", 'p', "PATH" ,0, "looks for .../<var>/update file in PATH, default is " SECVARPATH},
+		{"help", '?', 0, 0, "Give this help list", 1},
+		{"usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{0}
 	};
 
@@ -53,7 +55,7 @@ int performWriteCommand(int argc, char* argv[])
 		"<AUTH_FILE> must be a properly generated authenticated variable file"
 	};
 
-	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER, 0, &args);
+	rc = argp_parse( &argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag)
 		goto out;
 
@@ -78,24 +80,16 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 {
 	struct Arguments *args = state->input;
 	int rc = SUCCESS;
-	// this checks to see if help/usage is requested
-	// argp can either exit() or raise no errors, we want to go to cleanup and then exit so we need a special flag
-	// this becomes extra sticky since --usage/--help never actually get passed to this function
-	if (args->helpFlag == 0) {
-		if (state->next == 0 && state->next + 1 < state->argc) {
-			if (strncmp("--u", state->argv[state->next + 1], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next + 1], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next + 1], strlen("-?")) == 0)
-				args->helpFlag = 1;
-		}
-		else if (state->next < state->argc)
-			if (strncmp("--u", state->argv[state->next], strlen("--u")) == 0 
-				|| strncmp("--h", state->argv[state->next], strlen("--h")) == 0
-				|| strncmp("-?", state->argv[state->next], strlen("-?")) == 0)
-				args->helpFlag = 1;
-	}
 
 	switch (key) {
+		case '?':
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
+			break;
+		case ARGP_OPT_USAGE_KEY:
+			args->helpFlag = 1;
+			argp_state_help(state, stdout, ARGP_HELP_USAGE);
+			break;
 		case 'p':
 			args->pathToSecVars = arg;
 			break;

--- a/backends/edk2-compat/edk2-svc-write.c
+++ b/backends/edk2-compat/edk2-svc-write.c
@@ -33,6 +33,7 @@ int performWriteCommand(int argc, char* argv[])
 		.helpFlag = 0, .inpValid = 0, 
 		.pathToSecVars = NULL, .inFile = NULL, .varName = NULL
 	};
+	// combine command and subcommand for usage/help messages
 	argv[0] = "secvarctl write";
 
 	struct argp_option options[] = 

--- a/backends/edk2-compat/edk2-svc-write.c
+++ b/backends/edk2-compat/edk2-svc-write.c
@@ -33,7 +33,6 @@ int performWriteCommand(int argc, char* argv[])
 		.helpFlag = 0, .inpValid = 0, 
 		.pathToSecVars = NULL, .inFile = NULL, .varName = NULL
 	};
-	// combine command and subcommand for usage/help messages
 	argv[0] = "secvarctl write";
 
 	struct argp_option options[] = 
@@ -58,7 +57,8 @@ int performWriteCommand(int argc, char* argv[])
 		goto out;
 
 
-	rc = updateSecVar(args.varName, args.inFile, args.pathToSecVars, args.inpValid);	
+	rc = updateSecVar(args.varName, args.inFile, args.pathToSecVars, args.inpValid);
+
 out:
 	if (!args.helpFlag) 
 		printf("RESULT: %s\n", rc ? "FAILURE" : "SUCCESS");

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -2,14 +2,14 @@
 /* Copyright 2021 IBM Corp.*/
 #ifndef EDK2_SVC_SKIBOOT_H
 #define EDK2_SVC_SKIBOOT_H
-#include <stdint.h> //for uint_16 stuff like that
+#include <stdint.h> // for uint_16 stuff like that
 #include <mbedtls/x509_crt.h> // for printCertInfo
-#include "../../../external/skiboot/include/secvar.h" //for secvar struct
+#include "../../../external/skiboot/include/secvar.h" // for secvar struct
 #include "../../../include/err.h"
 #include "../../../include/prlog.h"
 #include "../../../include/generic.h"
 #include "../../../external/extraMbedtls/include/generate-pkcs7.h"
-#include "../../../external/skiboot/include/edk2.h" //include last or else problems from pragma pack(1)
+#include "../../../external/skiboot/include/edk2.h" // include last or else problems from pragma pack(1)
 
 
 #define CERT_BUFFER_SIZE        2048

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -11,7 +11,9 @@
 #include "../../../external/extraMbedtls/include/generate-pkcs7.h"
 #include "../../../external/skiboot/include/edk2.h" // include last or else problems from pragma pack(1)
 
-
+// all argp options must have a single character option 
+// so we set --usage to have a single character option that is out of range
+#define ARGP_OPT_USAGE_KEY 0x100
 #define CERT_BUFFER_SIZE        2048
 
 #ifndef SECVARPATH

--- a/external/extraMbedtls/generate-pkcs7.c
+++ b/external/extraMbedtls/generate-pkcs7.c
@@ -58,7 +58,7 @@ typedef struct PKCS7Info {
 	int newDataSize;
 	mbedtls_md_type_t hashFunct;
 	const char * hashFunctOID; 
-	int alreadySignedFlag; //if this is 1 then then PKCS7Info.keys contains signatures, if 0 then contains siging key in DER format 
+	int alreadySignedFlag; // if this is 1 then then PKCS7Info.keys contains signatures, if 0 then contains siging key in DER format 
 
 } PKCS7Info;
 #endif
@@ -76,7 +76,7 @@ int convert_pem_to_der( const unsigned char *input, size_t ilen,
     size_t len = 0;
     unsigned char *inpCpy;
 
-    //ensure last byte of input is NULL so that strstr knows where to stop 
+    // ensure last byte of input is NULL so that strstr knows where to stop 
     inpCpy = calloc(1, ilen + 1);
     memcpy(inpCpy, input, ilen);
     end = inpCpy + ilen;
@@ -375,8 +375,8 @@ static int setAlgorithmIDs(unsigned char **start, size_t *size, unsigned char **
 	int rc;
 	char *sigType = NULL;
 	
-	//if the private key already holds signature (see definition of pkcs7Info.keys)
-	//then just write the signature, no generation is needed
+	// if the private key already holds signature (see definition of pkcs7Info.keys)
+	// then just write the signature, no generation is needed
 	if (pkcs7Info->alreadySignedFlag) {
 		rc = setPKCS7Data(start, size, ptr, MBEDTLS_ASN1_OCTET_STRING, priv, privSize, 0);
 		if (rc)
@@ -607,7 +607,7 @@ static int toPKCS7(unsigned char **pkcs7, size_t *pkcs7Size, const char** crtFil
 		return ALLOC_FAIL;
 	}
 	for (int i = 0; i < keyPairs; i++) {
-		//get data from public keys
+		// get data from public keys
 		crtPEM = (unsigned char *)getDataFromFile(crtFiles[i], &crtSizePEM);
 		if (!crtPEM) {
 			prlog(PR_ERR, "ERROR: failed to get data from pub key file %s\n", crtFiles[i]);

--- a/generic.c
+++ b/generic.c
@@ -164,3 +164,31 @@ int createFile(const char * file, const char * buff, size_t size)
 	return SUCCESS;
 }
 
+/*
+ *returns a new pointer to an array with new length
+ *@param arr , a pointer to the array, will be reallocated to have new_length*size_each bytes or NULL if error
+ *@param new_length , the desired number of elements
+ *@param size_each , size of each elements
+ *@return 0 for success or ALLOC_FAIL if fail (memory will be freed in this case)
+ */
+int reallocArray(void **arr, size_t new_length, size_t size_each)
+{
+	void *old_arr;
+	size_t new_size;
+	//if realloc returns null it does not free memory so we must keep a pointer to it
+	old_arr = *arr;
+	//check if requested size is too big
+	if (__builtin_mul_overflow(new_length, size_each, &new_size)) {
+		prlog(PR_ERR, "ERROR: Invalid size to alloc %zd * %zd\n", new_length, size_each);
+		goto out;
+	}
+	*arr = realloc(*arr, size_each*new_length);
+	if (*arr == NULL)
+		goto out;
+
+	return SUCCESS;
+
+out:
+	free(old_arr);
+  	return ALLOC_FAIL;
+}

--- a/generic.c
+++ b/generic.c
@@ -2,7 +2,7 @@
 /* Copyright 2021 IBM Corp.*/
 #include <stdio.h>
 #include <string.h>
-#include <errno.h>	//strerror
+#include <errno.h>	// strerror
 #include <stdlib.h>
 #include <fcntl.h> // O_WRONLY
 #include <unistd.h> // has read/open funcitons

--- a/include/generic.h
+++ b/include/generic.h
@@ -15,4 +15,5 @@ void printRaw(const char* c, size_t size) ;
 int isFile(const char* path);
 size_t getLeadingWhitespace(unsigned char* data, size_t dataSize);
 void printHex(unsigned char* data, size_t length);
+int reallocArray(void **arr, size_t new_length, size_t size_each);
 #endif

--- a/include/secvarctl.h
+++ b/include/secvarctl.h
@@ -2,7 +2,7 @@
 /* Copyright 2021 IBM Corp.*/
 #ifndef SECVARCTL_H
 #define SECVARCTL_H
-#include <stdint.h> //for uint_16 stuff like that
+#include <stdint.h> // for uint_16 stuff like that
 #include "err.h"
 #include "prlog.h"
 #include "../backends/edk2-compat/include/edk2-svc.h"

--- a/secvarctl.1
+++ b/secvarctl.1
@@ -189,7 +189,7 @@ to force to generation.  If [h]ash is input or output type be sure to specify th
 .B -s 
 <sigFile> in replacement of the private key argument. <sigFile> would contain only the raw signed data of a digest generated with `secvarctl generate c:x`, it is important that both these commands use the same custom timestamp argument 
 .B -t
-<y-m-d h:m:s>.
+<YYYY-MM-DDThh:mm:ss>.
  When generating an [a]uth file, it is required the user give the secure variable name that the auth file is for,
 .B -n
 <varName> , where <varName> is one of {"PK","KEK", "db", "dbx"}. This argument is also useful when the input file is an ESL for the dbx (use 
@@ -197,7 +197,7 @@ to force to generation.  If [h]ash is input or output type be sure to specify th
 dbx) because then the prevalidation will look for an ESL containing a hash rather than an x509.
  Also, when the output type is a [p]kcs7 or [a]uth file, the user can use a custom timestamp with 
 .B -t 
-<time> , where <time> is in the format "y-m-d h:m:s". If this argument is not used then the current date and time are used.
+<time> , where <time> is in the format 'YYYY-MM-DDThh:mm:ss'. If this argument is not used then the current date and time are used.
  When using the input type '[f]ile' it will be assumed to be a text file and if output file is '[e]sl', '[p]kcs7' or '[a]uth' it will be hashed according to <hashAlg> (default SHA256).
  To make a variable reset file, the user can replace
 .B generate <inputFormat>:<outputFormat> 
@@ -374,7 +374,19 @@ OPTIONAL:
 <varName> , name of secure boot variable, used when generating an auth file, PKCS7, or when the input file contains hashed data rather than x509 (use '-n dbx'), current <varName> are: {'PK','KEK','db','dbx'}
 .PP
 .B -t 
-<time> , where time is of the format 'y-m-d h:m:s'. creates a custom timestamp used when generating an auth or PKCS7 file, if not given then current time is used
+<time> , where <time> is of the format described below. creates a custom timestamp used when generating an auth or PKCS7 file, if not given then current time is used, all times are in UTC
+.RS 
+format of <time> = 'YYYY-MM-DDThh:mm:ss' where:
+.RS
+- 'YYYY' four-digit year
+ - 'MM' two-digit month (01=January, etc.)
+ - 'DD' two-digit day of month (01 through 31)
+ - 'T' appears literally
+ - 'hh' two digits of hour (00 through 23) (am/pm NOT allowed)
+ - 'mm' two digits of minute (00 through 59)
+ - 'ss' two digits of second (00 through 59)
+.RE
+.RE
 .PP
 .B -h 
 <hashAlg> , hash function, used when output or input format is hash, current values for <hashAlg> are : {'SHA256', 'SHA224', 'SHA1', 'SHA384', 'SHA512'}
@@ -439,15 +451,15 @@ To create an auth file from a certificate for a KEK update (this will create an 
       $secvarctl generate c:a -k signer.key -c signer.crt -n KEK -i file.crt -o file.auth 
 .PP
 To create a PKCS7 file from an ESL for a db update with a custom timestamp:
-      $secvarctl generate e:p -k signer.key -c signer.crt -n db -t 2020-10-1 13:45:42 -i file.crt -o file.pkcs7 
+      $secvarctl generate e:p -k signer.key -c signer.crt -n db -t 2020-10-1T13:45:42 -i file.crt -o file.pkcs7 
 .PP
 To create an empty update to reset the db variable:
       $secvarctl generate reset -k signer.key -c signer.crt -n db -o db.auth 
 .PP
 To create an auth file using an external signing framework for db update:
-      $secvarctl generate c:x -n db -t 2021-1-1 1:1:1 -i file.crt -o file.hash
+      $secvarctl generate c:x -n db -t 2021-1-1T1:1:1 -i file.crt -o file.hash
       <user sends file.hash to be signed by external entity, signature is now in file.sig>
-      $secvarctl generate c:a -n db -t 2021-1-1 1:1:1 -c signer.crt -s file.sig -i file.crt -o file.auth 
+      $secvarctl generate c:a -n db -t 2021-1-1T1:1:1 -c signer.crt -s file.sig -i file.crt -o file.auth 
 
 .SH AUTHOR
 Nick Child nick.child@ibm.com,

--- a/secvarctl.c
+++ b/secvarctl.c
@@ -89,8 +89,6 @@ int main(int argc, char *argv[])
 
 	// next command should be one of main subcommands
 	subcommand = *argv; 
-	argv++;
-	argc--;
 
 	rc = UNKNOWN_COMMAND;
 	for (i = 0; i < backend->countCmds; i++) {

--- a/secvarctl.c
+++ b/secvarctl.c
@@ -124,7 +124,7 @@ static struct backend *getBackend()
 		prlog(PR_WARNING, "WARNING!! Could not extract data from %s , assuming platform does not support secure variables\n", secVarFormatLocation);
 		goto out;
 	}
-	//loop through all known backends
+	// loop through all known backends
 	for (int i = 0; i < sizeof(backends) / sizeof(struct backend); i++) {
 		if (!strncmp(buff, backends[i].name, strlen(backends[i].name))) {
 			prlog(PR_NOTICE, "Found Backend %s\n", backends[i].name);

--- a/test/runSvcGenerateTests.py
+++ b/test/runSvcGenerateTests.py
@@ -44,12 +44,13 @@ badSignedCommands = [
 [["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n"], False], #no var name
 [["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "foo"], False], #Invalid var
 [["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t","2020-10-2010:2:20", ], False], #Wrong timestamp format
-[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "10:2:20", "2020-10-20"], False], #Wrong timestamp order
-[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-50-20", "10:2:20" ], False], #bad month
-[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-200", "10:2:20" ], False], #bad day
-[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20", "25:2:20" ], False], #bad hour
-[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20", "10:61:20" ], False], #bad minute
-[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20", "10:2:61" ], False], #bad sec
+[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "10:2:20T2020-10-20"], False], #Wrong timestamp order
+[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-50-20T10:2:20" ], False], #bad month
+[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-200T10:2:20" ], False], #bad day
+[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20T25:2:20" ], False], #bad hour
+[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20T10:61:20" ], False], #bad minute
+[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20T10:2:61" ], False], #bad sec
+[["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t" ], False], #no timestammp arg
 [["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db"], False], #no key file
 [["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k","./testdata/goldenKeys/PK/PK.key", "-c","-n", "db"], False], #no crt file
 [["e:a", "-i", "./testdata/db_by_PK.esl", "-o", OUTDIR+"foo.auth", "-k","./testdata/goldenKeys/PK/PK.key","-c", "./testdata/goldenKeys/PK/PK.crt",  "-c", "./testdata/goldenKeys/KEK/KEK.crt", "-n", "db"], False], #crt != #keys
@@ -259,9 +260,9 @@ class Test(unittest.TestCase):
 		#now test custom timestamp works
 		customTSAuth1 = OUTDIR+"db_by_PK_customTS1.auth"
 		customTSAuth2 = OUTDIR+"db_by_PK_customTS2.auth"
-		self.assertEqual( getCmdResult(cmd+ ["e:a", "-i", "./testdata/db_by_PK.esl", "-o", customTSAuth1, "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20", "10:2:8" ], out, self), True) 
+		self.assertEqual( getCmdResult(cmd+ ["e:a", "-i", "./testdata/db_by_PK.esl", "-o", customTSAuth1, "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20T10:2:8" ], out, self), True) 
 		time.sleep(4)
-		self.assertEqual( getCmdResult(cmd+ ["e:a", "-i", "./testdata/db_by_PK.esl", "-o", customTSAuth2, "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20", "10:2:8" ], out, self), True) 
+		self.assertEqual( getCmdResult(cmd+ ["e:a", "-i", "./testdata/db_by_PK.esl", "-o", customTSAuth2, "-k", "./testdata/goldenKeys/PK/PK.key", "-c", "./testdata/goldenKeys/PK/PK.crt", "-n", "db", "-t", "2020-10-20T10:2:8" ], out, self), True) 
 		self.assertEqual( getCmdResult([SECTOOLS, "validate", customTSAuth1], out, self), True)
 		self.assertEqual( getCmdResult([SECTOOLS, "validate", customTSAuth2], out, self), True)
 		self.assertEqual( compareFiles(customTSAuth1, customTSAuth2), True)
@@ -327,7 +328,7 @@ class Test(unittest.TestCase):
 
 	def test_genExternalSig(self):
 		out = "genExternalSigLog.txt"
-		timestamp = ["-t", "2020-1-1","1:1:1"]
+		timestamp = ["-t", "2020-1-1T1:1:1"]
 		inpCrt = "./testdata/db_by_KEK.crt"
 		sigCrt = "./testdata/goldenKeys/KEK/KEK.crt"
 		sigKey = "./testdata/goldenKeys/KEK/KEK.key"


### PR DESCRIPTION
This PR is to replace the current argument parsing scheme with one that incorporates argp. Argp is a package from the GNU C standard library, it greatly reduces the need for argument parsing functions and autogenerates help and usage messages. This PR contains commits that add the argp implementation to each of the subcommands {'read', 'write', 'verify', 'validate', 'generate' }. This PR does not alter or remove any of the current command line arguments. However, it does add long flags for almost all of the options (ex: `-v` can also be specified with `--verbose`). It is very likely that another commit may be added in the future to trim some of the added source code. For example, every subcommand individually creates the 'program name' argument by concatenating the first and second command line element. This method was just favorable when I was editing and testing every command one by one. Now that they all work and use the same logic, I will likely move this operation to the `main` function to avoid duplicate code.  