### PR TITLE
Make Makeover

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,40 +4,25 @@ cmake_minimum_required( VERSION 3.12 )
 project( secvarctl C )
 
 set( CMAKE_C_COMPILER gcc )
-#sources/dependencies for secvarctl
-set( DEPEN secvarctl.h prlog.h err.h generic.h )
-set( DEPDIR include/ )
-list( TRANSFORM DEPEN PREPEND ${DEPDIR} )
+#sources for secvarctl
 set( SRC secvarctl.c generic.c )
 
-#sources/dependencies for edk2 backend
-set( EDK2DEPEN edk2-svc.h )
-set( EDK2DEPDIR backends/edk2-compat/include/ )
-list( TRANSFORM EDK2DEPEN PREPEND ${EDK2DEPDIR} )
+#sources for edk2 backend
 set ( EDK2SRC edk2-svc-read.c edk2-svc-write.c edk2-svc-validate.c edk2-svc-verify.c edk2-svc-generate.c )
 set ( EDK2SRCDIR backends/edk2-compat/ )
 list( TRANSFORM EDK2SRC PREPEND ${EDK2SRCDIR} )
-list( APPEND DEPEN ${EDK2DEPEN} )
 list( APPEND SRC ${EDK2SRC} )
 
-#sources/dependencies for borrowed skiboot code
-set( SKIBOOTDEPEN list.h config.h container_of.h check_type.h secvar.h opal-api.h endian.h short_types.h edk2.h edk2-compat-process.h )
-set( SKIBOOTDEPDIR external/skiboot/include/ )
-list( TRANSFORM SKIBOOTDEPEN PREPEND ${SKIBOOTDEPDIR} )
+#sources for borrowed skiboot code
 set ( SKIBOOTSRC secvar_util.c edk2-compat.c edk2-compat-process.c )
 set ( SKIBOOTSRCDIR external/skiboot/ )
 list( TRANSFORM SKIBOOTSRC PREPEND ${SKIBOOTSRCDIR} )
-list( APPEND DEPEN ${SKIBOOTDEPEN} )
 list( APPEND SRC ${SKIBOOTSRC} )
 
-#sources/dependencies for extra mbedtls functions
-set( EXTRAMBEDTLSDEP generate-pkcs7.h pkcs7.h )
-set( EXTRAMBEDTLSDEPDIR external/extraMbedtls/include/ )
-list( TRANSFORM EXTRAMBEDTLSDEP PREPEND ${EXTRAMBEDTLSDEPDIR} )
+#sources for extra mbedtls functions
 set ( EXTRAMBEDTLSSRC generate-pkcs7.c pkcs7.c )
 set ( EXTRAMBEDTLSSRCDIR  external/extraMbedtls/ )
 list( TRANSFORM EXTRAMBEDTLSSRC PREPEND ${EXTRAMBEDTLSSRCDIR} )
-list( APPEND DEPEN ${EXTRAMBEDTLSDEP} )
 list( APPEND SRC ${EXTRAMBEDTLSSRC} )
 
 add_executable( secvarctl ${SRC} )
@@ -94,8 +79,6 @@ set( CMAKE_C_FLAGS_COVERAGE    "-O0 -g3 -fprofile-arcs -ftest-coverage" )
 
 
 target_compile_options( secvarctl PRIVATE -Wall -Werror )
-
-
 
 #set c standard
 set( CMAKE_C_STANDARD 99 )

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Copyright 2021 IBM Corp.
 #_*_MakeFile_*_
 CC = gcc 
-_CFLAGS = -O2 -std=gnu99 -Wall -Werror
+_CFLAGS = -MMD -O2 -std=gnu99 -Wall -Werror
 LFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto
 
 DEBUG ?= 0
@@ -11,25 +11,6 @@ _CFLAGS += -g
 else
 _CFLAGS += -s
 endif
-
-_DEPEN = secvarctl.h prlog.h err.h generic.h 
-DEPDIR = include
-DEPEN = $(patsubst %,$(DEPDIR)/%, $(_DEPEN))
-
-_EDK2_DEPEN = edk2-svc.h 
-EDK2DEPDIR = backends/edk2-compat/include
-EDK2_DEPEN = $(patsubst %,$(EDK2DEPDIR)/%, $(_EDK2_DEPEN))
-DEPEN += $(EDK2_DEPEN)
-
-_SKIBOOT_DEPEN =list.h config.h container_of.h check_type.h secvar.h opal-api.h endian.h short_types.h edk2.h edk2-compat-process.h
-SKIBOOTDEPDIR = external/skiboot/include
-SKIBOOT_DEPEN = $(patsubst %,$(SKIBOOTDEPDIR)/%, $(_SKIBOOT_DEPEN))
-DEPEN += $(SKIBOOT_DEPEN)
-
-_EXTRAMBEDTLS_DEPEN = pkcs7.h generate-pkcs7.h 
-EXTRAMBEDTLSDEPDIR = external/extraMbedtls/include
-EXTRAMBEDTLSDEPEN = $(patsubst %,$(EXTRAMBEDTLSDEPDIR)/%, $(_EXTRAMBEDTLS_DEPEN))
-DEPEN += $(EXTRAMBEDTLSDEPEN)
 
 EDK2OBJDIR = backends/edk2-compat
 _EDK2_OBJ =  edk2-svc-read.o edk2-svc-write.o edk2-svc-validate.o edk2-svc-verify.o edk2-svc-generate.o
@@ -68,20 +49,16 @@ endif
 secvarctl: $(OBJ) 
 	$(CC) $(CFLAGS) $(_CFLAGS) $(STATICFLAG) $^  -o $@ $(LFLAGS)
 
-
-
-%.o: %.c $(DEPEN)
+%.o: %.c
 	$(CC) $(CFLAGS) $(_CFLAGS) -c  $< -o $@
 
 clean:
 	rm -f $(OBJ) secvarctl 
+	rm -f $(OBJ:.o=.d)
 	rm -f ./*/*.cov.* secvarctl-cov ./*.cov.* ./backends/*/*.cov.* ./external/*/*.cov.* ./html*
 
-
-%.cov.o: %.c $(DEPEN)
+%.cov.o: %.c
 	$(CC) $(CFLAGS) $(_CFLAGS) -c  --coverage $< -o $@
-
-
 
 secvarctl-cov: $(OBJCOV) 
 	$(CC) $(CFLAGS) $(_CFLAGS) $^  $(STATICFLAG) -fprofile-arcs -ftest-coverage -o $@ $(LFLAGS)
@@ -91,3 +68,5 @@ install: secvarctl
 	install -m 0755 secvarctl $(DESTDIR)/usr/bin/secvarctl
 	mkdir -p $(DESTDIR)/$(MANDIR)/man1
 	install -m 0644 secvarctl.1 $(DESTDIR)/$(MANDIR)/man1
+
+-include $(OBJ:.o=.d)

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,15 @@
 # Copyright 2021 IBM Corp.
 #_*_MakeFile_*_
 CC = gcc 
-_CFLAGS = -s -O2 -std=gnu99 -Wall -Werror
+_CFLAGS = -O2 -std=gnu99 -Wall -Werror
 LFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto
+
+DEBUG ?= 0
+ifeq ($(DEBUG),1)
+_CFLAGS += -g
+else
+_CFLAGS += -s
+endif
 
 _DEPEN = secvarctl.h prlog.h err.h generic.h 
 DEPDIR = include

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #_*_MakeFile_*_
 CC = gcc 
 _CFLAGS = -MMD -O2 -std=gnu99 -Wall -Werror
-LFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto
+_LDFLAGS = -lmbedtls -lmbedx509 -lmbedcrypto
 
 DEBUG ?= 0
 ifeq ($(DEBUG),1)
@@ -34,7 +34,7 @@ MANDIR=usr/local/share/man
 STATIC = 0
 ifeq ($(STATIC),1)
 	STATICFLAG=-static
-	LFLAGS +=-lpthread
+	_LDFLAGS +=-lpthread
 else 
 	STATICFLAG=
 endif
@@ -47,7 +47,7 @@ endif
 
 
 secvarctl: $(OBJ) 
-	$(CC) $(CFLAGS) $(_CFLAGS) $(STATICFLAG) $^  -o $@ $(LFLAGS)
+	$(CC) $(CFLAGS) $(_CFLAGS) $(STATICFLAG) $^  -o $@ $(LDFLAGS) $(_LDFLAGS)
 
 %.o: %.c
 	$(CC) $(CFLAGS) $(_CFLAGS) -c  $< -o $@
@@ -61,7 +61,7 @@ clean:
 	$(CC) $(CFLAGS) $(_CFLAGS) -c  --coverage $< -o $@
 
 secvarctl-cov: $(OBJCOV) 
-	$(CC) $(CFLAGS) $(_CFLAGS) $^  $(STATICFLAG) -fprofile-arcs -ftest-coverage -o $@ $(LFLAGS)
+	$(CC) $(CFLAGS) $(_CFLAGS) $^  $(STATICFLAG) -fprofile-arcs -ftest-coverage -o $@ $(LDFLAGS) $(_LDFLAGS)
 
 install: secvarctl
 	mkdir -p $(DESTDIR)/usr/bin

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ DEBUG ?= 0
 ifeq ($(DEBUG),1)
 _CFLAGS += -g
 else
-_CFLAGS += -s
+_LDFLAGS += -s
 endif
 
 EDK2OBJDIR = backends/edk2-compat

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
  | Static Build | `STATIC=1` | `-DSTATIC=1`|
  | Reduced Size Build | default | `-DSTRIP=1` |
  | Build Without Crypto Functions | `NO_CRYPTO=1` | `-DNO_CRYPTO=1` |
- | Build W Specific Mbedtls Library | `CFLAGS="-L<path>/library -I<path>/include"` | `-DCUSTOM_MBEDTLS=<path>` |
+ | Build W Specific Mbedtls Library | `CFLAGS="-I<path>/include" LDFLAGS="-L<path>/library"` | `-DCUSTOM_MBEDTLS=<path>` |
  | Build for Coverage Tests | `make [options] secvarctl-cov` | `-DCMAKE_BUILD_TYPE=Coverage` |
  | Install    | `make install`        | `cmake --install .`|
  


### PR DESCRIPTION
This PR simplifies and improves our make processes.

Both cmake and makefiles support automatic dependency tracking, so you don't have to manually specify every header file that a source file depends on. 

For Make, we do this with the `-MMD` argument to gcc, which creates `.d` files that list the dependencies as a Make rule. We import those files into our makefile if they exist.

CMake does this automagically, I think with it's own parser.

I also:
 * add a `DEBUG` mode for the Makefile which stops stripping symbols and adds debug code.
 * rename `LFLAGS` to the more common `LDFLAGS`
 * do misc cleanups