### PR TITLE
Respond to Static Analysis Warnings

### DIFF
--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -495,7 +495,7 @@ static int getCurrentVars(char *newCurr[], int *size, const char* path)
  */
 static void printBanks(struct list_head *variable_bank,struct list_head *update_bank)
 {
-	struct secvar *var;
+	struct secvar *var = NULL;
 	printf("----CONTENTS OF UPDATE BANK----\n");
 	list_for_each(update_bank, var,link) {
 		printf("SecVar for %s contains %zd bytes of data\n", var->key, var->data_size);
@@ -516,7 +516,7 @@ static void printBanks(struct list_head *variable_bank,struct list_head *update_
 static int commitUpdateBank(struct list_head *update_bank, const char *path)
 {
 	int rc = INVALID_FILE;
-	struct secvar *var;
+	struct secvar *var = NULL;
 	list_for_each(update_bank, var, link) {
 		prlog(PR_INFO, "Writing new %s with %zd bytes of data to %s%s/update\n",var->key, var->data_size, path, var->key);
 		rc = updateVar(path, var->key, (unsigned char *)var->data, var->data_size);

--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -296,7 +296,11 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 			prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 			return ALLOC_FAIL;
 		}
-		getCurrentVars(currentVars, &currCount, path);	
+		// unlikely fail, if alloc fails
+		if (getCurrentVars(currentVars, &currCount, path)) {
+			prlog(PR_ERR, "Could not get current variables from path %s\n", path);
+			return INVALID_FILE;
+		}
 	}
 
 	// once here, strings should be ready, it is time to fill banks

--- a/external/extraMbedtls/generate-pkcs7.c
+++ b/external/extraMbedtls/generate-pkcs7.c
@@ -604,7 +604,8 @@ static int toPKCS7(unsigned char **pkcs7, size_t *pkcs7Size, const char** crtFil
 	crtSizes = calloc(1, sizeof(size_t) * keyPairs);
 	if (!crts || !crtSizes) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
-		return ALLOC_FAIL;
+		rc = ALLOC_FAIL;
+		goto out;
 	}
 	for (int i = 0; i < keyPairs; i++) {
 		// get data from public keys
@@ -714,7 +715,8 @@ int to_pkcs7_generate_signature(unsigned char **pkcs7, size_t *pkcs7Size, const 
 	keySizes = calloc(1, sizeof(size_t) * keyPairs);
 	if (!keys || !keySizes) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
-		return ALLOC_FAIL;	
+		rc = ALLOC_FAIL;
+		goto out;	
 	}
 
 	for (int i = 0; i < keyPairs; i++) {
@@ -789,7 +791,8 @@ int to_pkcs7_already_signed_data(unsigned char **pkcs7, size_t *pkcs7Size, const
 	sig_sizes = calloc(1, sizeof(size_t) * keyPairs);
 	if (!sigs || !sig_sizes) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
-		return ALLOC_FAIL;	
+		rc = ALLOC_FAIL;
+		goto out;	
 	}
 
 	for (int i = 0; i < keyPairs; i++) {

--- a/external/extraMbedtls/generate-pkcs7.c
+++ b/external/extraMbedtls/generate-pkcs7.c
@@ -600,7 +600,7 @@ static int toPKCS7(unsigned char **pkcs7, size_t *pkcs7Size, const char** crtFil
 	size_t crtSizePEM,*crtSizes = NULL, pkcs7BuffSize, whiteSpace, oidLen; 
 	int rc;
 
-	crts = calloc (1, sizeof(char*) * keyPairs);
+	crts = calloc (1, sizeof(unsigned char*) * keyPairs);
 	crtSizes = calloc(1, sizeof(size_t) * keyPairs);
 	if (!crts || !crtSizes) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
@@ -711,7 +711,7 @@ int to_pkcs7_generate_signature(unsigned char **pkcs7, size_t *pkcs7Size, const 
 		rc = ARG_PARSE_FAIL;
 		goto out;
 	}
-	keys = calloc(1, sizeof(char*) * keyPairs);
+	keys = calloc(1, sizeof(unsigned char*) * keyPairs);
 	keySizes = calloc(1, sizeof(size_t) * keyPairs);
 	if (!keys || !keySizes) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");

--- a/external/extraMbedtls/pkcs7.c
+++ b/external/extraMbedtls/pkcs7.c
@@ -78,8 +78,10 @@ int mbedtls_pkcs7_load_file( const char *path, unsigned char **buf, size_t *n )
     *n = (size_t) st.st_size;
 
     *buf = mbedtls_calloc( 1, *n + 1 );
-    if( *buf == NULL )
+    if( *buf == NULL ) {
+        fclose( file );
         return( MBEDTLS_ERR_PKCS7_ALLOC_FAILED );
+    }
 
     if( fread( *buf, 1, *n, file ) != *n )
     {

--- a/external/skiboot/secvar_util.c
+++ b/external/skiboot/secvar_util.c
@@ -52,7 +52,7 @@ struct secvar *alloc_secvar(uint64_t key_len, uint64_t data_size)
 
 	ret->key = zalloc(key_len);
 	if (!ret->key) {
-		free(ret->key);
+		free(ret);
 		return NULL;
 	}
 


### PR DESCRIPTION
This pull request contains a series of commits that react to warnings left by various static analysis tools. It is branched off of the openssl Pull Request, available [here](https://github.com/open-power/secvarctl/pull/11), and is therefore dependent on that being merged. The tools used were `cppcheck`,  `scan-build` and gcc's `-fanalyzer` . Most of the commits are very small and mainly deal with freeing or closing memory and files if a rare error occurs (like memory allocation failure). That being said, a bug is a bug and worthy of being patched!