### PR TITLE
Makefile: Remember to cleanup crypto-openssl files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,9 @@ secvarctl: $(OBJ)
 %.o: %.c
 	$(CC) $(CFLAGS) $(_CFLAGS) -c  $< -o $@
 
+clean:OBJ += crypto/crypto-openssl.o
 clean:
-	rm -f $(OBJ) secvarctl 
+	rm -f $(OBJ) secvarctl
 	rm -f $(OBJ:.o=.d)
 	rm -f ./*/*.cov.* secvarctl-cov ./*.cov.* ./backends/*/*.cov.* ./external/*/*.cov.* ./html*
 


### PR DESCRIPTION
This commit ensures that crypto-openssl.o/d get deleted with `make clean`. Previously, this was not happening since the make variable $(OBJ) is different when the project is being built then when it is being cleaned. Since the flag `OPENSSL=1` is (and should be) only specified with the build command, it only adds the crypto-openssl.o file to $(OBJ) during `make OPENSSL=1` and not `make clean`. So when the user specifies `make clean` the Makefile removes all files contained in $(OBJ) since the command was `make clean` and not `make OPENSSL=1 clean` the openssl files are not deleted. This commit ensures that all possible compiled files are removed (regardless of the flags used for the build command).

Signed-off-by: Nick Child <nick.child@ibm.com>