### PR TITLE
Further syncing with skiboot

### DIFF
--- a/backends/edk2-compat/edk2-svc-generate.c
+++ b/backends/edk2-compat/edk2-svc-generate.c
@@ -25,47 +25,38 @@ enum pkcs7_generation_method {
 struct Arguments {
 	// the pkcs7_gen_meth is to determine if signKeys stores a private key file(0) or signed data (1)
 	int helpFlag, inpValid, signKeyCount, signCertCount;
-	const char *inFile, *outFile, **signCerts, **signKeys, *inForm,
-		*outForm, *varName, *hashAlg;
+	const char *inFile, *outFile, **signCerts, **signKeys, *inForm, *outForm, *varName,
+		*hashAlg;
 	struct efi_time *time;
 	enum pkcs7_generation_method pkcs7_gen_meth;
 };
 
 static int parse_opt(int key, char *arg, struct argp_state *state);
-static int generateHash(const unsigned char *data, size_t size,
-			struct Arguments *args, const struct hash_funct *alg,
-			unsigned char **outHash, size_t *outHashSize);
+static int generateHash(const unsigned char *data, size_t size, struct Arguments *args,
+			const struct hash_funct *alg, unsigned char **outHash, size_t *outHashSize);
 static int validateHashAndAlg(size_t size, const struct hash_funct *alg);
-static int toESL(const unsigned char *data, size_t size, const uuid_t guid,
-		 unsigned char **outESL, size_t *outESLSize);
+static int toESL(const unsigned char *data, size_t size, const uuid_t guid, unsigned char **outESL,
+		 size_t *outESLSize);
 static int getHashFunction(const char *name, struct hash_funct **returnFunct);
-static int toPKCS7ForSecVar(const unsigned char *newData, size_t dataSize,
-			    struct Arguments *args, int hashFunct,
-			    unsigned char **outBuff, size_t *outBuffSize);
-static int toAuth(const unsigned char *newESL, size_t eslSize,
-		  struct Arguments *args, int hashFunct,
-		  unsigned char **outBuff, size_t *outBuffSize);
-static int generateESL(const unsigned char *buff, size_t size,
-		       struct Arguments *args,
-		       const struct hash_funct *hashFunct,
-		       unsigned char **outBuff, size_t *outBuffSize);
-static int generateAuthOrPKCS7(const unsigned char *buff, size_t size,
-			       struct Arguments *args,
-			       const struct hash_funct *hashFunct,
-			       unsigned char **outBuff, size_t *outBuffSize);
+static int toPKCS7ForSecVar(const unsigned char *newData, size_t dataSize, struct Arguments *args,
+			    int hashFunct, unsigned char **outBuff, size_t *outBuffSize);
+static int toAuth(const unsigned char *newESL, size_t eslSize, struct Arguments *args,
+		  int hashFunct, unsigned char **outBuff, size_t *outBuffSize);
+static int generateESL(const unsigned char *buff, size_t size, struct Arguments *args,
+		       const struct hash_funct *hashFunct, unsigned char **outBuff,
+		       size_t *outBuffSize);
+static int generateAuthOrPKCS7(const unsigned char *buff, size_t size, struct Arguments *args,
+			       const struct hash_funct *hashFunct, unsigned char **outBuff,
+			       size_t *outBuffSize);
 static int getTimestamp(struct efi_time *ts);
-static int getOutputData(const unsigned char *buff, size_t size,
-			 struct Arguments *args,
-			 const struct hash_funct *hashFunction,
-			 unsigned char **outBuff, size_t *outBuffSize);
-static int authToESL(const unsigned char *in, size_t inSize,
-		     unsigned char **out, size_t *outSize);
-static int toHashForSecVarSigning(const unsigned char *ESL, size_t ESL_size,
-				  struct Arguments *args,
+static int getOutputData(const unsigned char *buff, size_t size, struct Arguments *args,
+			 const struct hash_funct *hashFunction, unsigned char **outBuff,
+			 size_t *outBuffSize);
+static int authToESL(const unsigned char *in, size_t inSize, unsigned char **out, size_t *outSize);
+static int toHashForSecVarSigning(const unsigned char *ESL, size_t ESL_size, struct Arguments *args,
 				  unsigned char **outBuff, size_t *outBuffSize);
-static int getPreHashForSecVar(unsigned char **outData, size_t *outSize,
-			       const unsigned char *ESL, size_t ESL_size,
-			       struct Arguments *args);
+static int getPreHashForSecVar(unsigned char **outData, size_t *outSize, const unsigned char *ESL,
+			       size_t ESL_size, struct Arguments *args);
 static int parseCustomTimestamp(struct efi_time *strct, const char *str);
 static void convert_tm_to_efi_time(struct efi_time *efi_t, struct tm *tm_t);
 /*
@@ -106,8 +97,7 @@ int performGenerateCommand(int argc, char *argv[])
 		{ "alg", 'h', "HASH_ALG", 0,
 		  "hash function, use when '[h]ash' is input/output format."
 		  " currently accepted values: {'SHA256', 'SHA224', 'SHA1', 'SHA384', 'SHA512'}, Default is 'SHA256'" },
-		{ "verbose", 'v', 0, 0,
-		  "print more verbose process information" },
+		{ "verbose", 'v', 0, 0, "print more verbose process information" },
 		{ "key", 'k', "FILE", 0,
 		  "private RSA key (PEM), used when signing data for PKCS7/Auth files"
 		  " must have a corresponding '-c FILE' ."
@@ -130,8 +120,7 @@ int performGenerateCommand(int argc, char *argv[])
 		{ 0, 'i', "FILE", OPTION_HIDDEN, "input file" },
 		{ 0, 'o', "FILE", OPTION_HIDDEN, "output file" },
 		{ "help", '?', 0, 0, "Give this help list", 1 },
-		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0,
-		  "Give a short usage message", -1 },
+		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{ 0 }
 	};
 
@@ -179,8 +168,7 @@ int performGenerateCommand(int argc, char *argv[])
 
 	};
 
-	rc = argp_parse(&argp, argc, argv,
-			ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
+	rc = argp_parse(&argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag)
 		goto out;
 
@@ -197,9 +185,8 @@ int performGenerateCommand(int argc, char *argv[])
 		rc = ARG_PARSE_FAIL;
 		goto out;
 	}
-	prlog(PR_INFO,
-	      "Input file is %s of type %s , output file is %s of type %s\n",
-	      args.inFile, args.inForm, args.outFile, args.outForm);
+	prlog(PR_INFO, "Input file is %s of type %s , output file is %s of type %s\n", args.inFile,
+	      args.inForm, args.outFile, args.outForm);
 
 	// if reset key than don't look for an input file
 	if (args.inForm[0] == 'r')
@@ -208,8 +195,7 @@ int performGenerateCommand(int argc, char *argv[])
 		// get data from input file
 		buff = (unsigned char *)getDataFromFile(args.inFile, &size);
 		if (buff == NULL) {
-			prlog(PR_ERR, "ERROR: Could not find data in file %s\n",
-			      args.inFile);
+			prlog(PR_ERR, "ERROR: Could not find data in file %s\n", args.inFile);
 			rc = INVALID_FILE;
 			goto out;
 		}
@@ -222,11 +208,9 @@ int performGenerateCommand(int argc, char *argv[])
 	if (rc)
 		goto out;
 	// now we can try to generate the desired output format
-	rc = getOutputData(buff, size, &args, hashFunction, &outBuff,
-			   &outBuffSize);
+	rc = getOutputData(buff, size, &args, hashFunction, &outBuff, &outBuffSize);
 	if (rc) {
-		prlog(PR_ERR, "Failed to generate into output format: %s\n",
-		      args.outForm);
+		prlog(PR_ERR, "Failed to generate into output format: %s\n", args.outForm);
 		goto out;
 	}
 
@@ -234,9 +218,7 @@ int performGenerateCommand(int argc, char *argv[])
 	// write data to new file
 	rc = createFile(args.outFile, (char *)outBuff, outBuffSize);
 	if (rc) {
-		prlog(PR_ERR,
-		      "ERROR: Could not write new data to output file %s\n",
-		      args.outFile);
+		prlog(PR_ERR, "ERROR: Could not write new data to output file %s\n", args.outFile);
 	}
 
 out:
@@ -289,20 +271,17 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		rc = reallocArray((void **)&args->signKeys, args->signKeyCount,
 				  sizeof(*args->signKeys));
 		if (rc) {
-			prlog(PR_ERR,
-			      "Failed to realloc private key (-k <>) array\n");
+			prlog(PR_ERR, "Failed to realloc private key (-k <>) array\n");
 			break;
 		}
 		args->signKeys[args->signKeyCount - 1] = arg;
 		break;
 	case 'c':
 		args->signCertCount++;
-		rc = reallocArray((void **)&args->signCerts,
-				  args->signCertCount,
+		rc = reallocArray((void **)&args->signCerts, args->signCertCount,
 				  sizeof(*args->signCerts));
 		if (rc) {
-			prlog(PR_ERR,
-			      "Failed to realloc certificate (-c <>) array\n");
+			prlog(PR_ERR, "Failed to realloc certificate (-c <>) array\n");
 			break;
 		}
 		args->signCerts[args->signCertCount - 1] = arg;
@@ -326,8 +305,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		rc = reallocArray((void **)&args->signKeys, args->signKeyCount,
 				  sizeof(*args->signKeys));
 		if (rc) {
-			prlog(PR_ERR,
-			      "Failed to realloc signature (-s <>) array\n");
+			prlog(PR_ERR, "Failed to realloc signature (-s <>) array\n");
 			break;
 		}
 		args->signKeys[args->signKeyCount - 1] = arg;
@@ -380,17 +358,12 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		else if (args->time && validateTime(args->time))
 			prlog(PR_ERR,
 			      "Invalid timestamp flag '-t YYYY-MM-DDThh:mm:ss' , see usage...\n");
-		else if (args->inForm[0] != 'r' &&
-			 (args->inFile == NULL || isFile(args->inFile)))
-			prlog(PR_ERR,
-			      "ERROR: Input File is invalid, see usage below...\n");
+		else if (args->inForm[0] != 'r' && (args->inFile == NULL || isFile(args->inFile)))
+			prlog(PR_ERR, "ERROR: Input File is invalid, see usage below...\n");
 		else if (args->varName && isVariable(args->varName))
-			prlog(PR_ERR,
-			      "ERROR: %s is not a valid variable name\n",
-			      args->varName);
+			prlog(PR_ERR, "ERROR: %s is not a valid variable name\n", args->varName);
 		else if (args->outFile == NULL)
-			prlog(PR_ERR,
-			      "ERROR: No output file given, see usage below...\n");
+			prlog(PR_ERR, "ERROR: No output file given, see usage below...\n");
 		else
 			break;
 		argp_usage(state);
@@ -419,8 +392,7 @@ static int parseCustomTimestamp(struct efi_time *strct, const char *str)
 	if (ret == NULL)
 		return INVALID_TIMESTAMP;
 	else if (*ret != '\0') {
-		prlog(PR_ERR, "ERROR: Failed to parse timestamp value at %s\n",
-		      ret);
+		prlog(PR_ERR, "ERROR: Failed to parse timestamp value at %s\n", ret);
 		return INVALID_TIMESTAMP;
 	}
 
@@ -437,10 +409,9 @@ static int parseCustomTimestamp(struct efi_time *strct, const char *str)
  *@param outBuffSize, the length of outBuff
  *@return SUCCESS or err number 
  */
-static int getOutputData(const unsigned char *buff, size_t size,
-			 struct Arguments *args,
-			 const struct hash_funct *hashFunction,
-			 unsigned char **outBuff, size_t *outBuffSize)
+static int getOutputData(const unsigned char *buff, size_t size, struct Arguments *args,
+			 const struct hash_funct *hashFunction, unsigned char **outBuff,
+			 size_t *outBuffSize)
 {
 	int rc;
 	// once here it is time to plan the course of action depending on the output type desired
@@ -449,8 +420,7 @@ static int getOutputData(const unsigned char *buff, size_t size,
 		rc = CERT_FAIL; // cannot generate a cert
 		break;
 	case 'h':
-		rc = generateHash(buff, size, args, hashFunction, outBuff,
-				  outBuffSize);
+		rc = generateHash(buff, size, args, hashFunction, outBuff, outBuffSize);
 		break;
 	case 'x':
 		// intentional flow
@@ -461,8 +431,7 @@ static int getOutputData(const unsigned char *buff, size_t size,
 		if (!args->time) {
 			args->time = calloc(1, sizeof(*args->time));
 			if (!args->time) {
-				prlog(PR_ERR,
-				      "ERROR: failed to allocate memory\n");
+				prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 				rc = ALLOC_FAIL;
 				goto out;
 			}
@@ -470,16 +439,13 @@ static int getOutputData(const unsigned char *buff, size_t size,
 			if (rc)
 				goto out;
 		}
-		rc = generateAuthOrPKCS7(buff, size, args, hashFunction,
-					 outBuff, outBuffSize);
+		rc = generateAuthOrPKCS7(buff, size, args, hashFunction, outBuff, outBuffSize);
 		break;
 	case 'e':
-		rc = generateESL(buff, size, args, hashFunction, outBuff,
-				 outBuffSize);
+		rc = generateESL(buff, size, args, hashFunction, outBuff, outBuffSize);
 		break;
 	default:
-		prlog(PR_ERR,
-		      "ERROR: Unknown output format %s, use `--help` for more info\n",
+		prlog(PR_ERR, "ERROR: Unknown output format %s, use `--help` for more info\n",
 		      args->outForm);
 		rc = ARG_PARSE_FAIL;
 	}
@@ -498,10 +464,9 @@ out:
  *@param outBuffSize, the length of outBuff
  *@return SUCCESS or err number 
  */
-static int generateAuthOrPKCS7(const unsigned char *buff, size_t size,
-			       struct Arguments *args,
-			       const struct hash_funct *hashFunct,
-			       unsigned char **outBuff, size_t *outBuffSize)
+static int generateAuthOrPKCS7(const unsigned char *buff, size_t size, struct Arguments *args,
+			       const struct hash_funct *hashFunct, unsigned char **outBuff,
+			       size_t *outBuffSize)
 {
 	int rc;
 	size_t intermediateBuffSize, inpSize = size;
@@ -527,8 +492,7 @@ static int generateAuthOrPKCS7(const unsigned char *buff, size_t size,
 		if (!args->inpValid) {
 			rc = validateESL(*inpPtr, inpSize, args->varName);
 			if (rc) {
-				prlog(PR_ERR,
-				      "ERROR: Could not validate ESL\n");
+				prlog(PR_ERR, "ERROR: Could not validate ESL\n");
 				break;
 			}
 		}
@@ -545,10 +509,8 @@ static int generateAuthOrPKCS7(const unsigned char *buff, size_t size,
 		}
 		break;
 	default:
-		prlog(PR_ERR,
-		      "ERROR: Unknown input format %s for generating %s file.\n",
-		      args->inForm,
-		      (args->outForm[0] == 'a' ? "an Auth" : "a PKCS7"));
+		prlog(PR_ERR, "ERROR: Unknown input format %s for generating %s file.\n",
+		      args->inForm, (args->outForm[0] == 'a' ? "an Auth" : "a PKCS7"));
 		rc = ARG_PARSE_FAIL;
 	}
 	if (rc) {
@@ -557,19 +519,16 @@ static int generateAuthOrPKCS7(const unsigned char *buff, size_t size,
 	}
 
 	if (args->outForm[0] == 'a')
-		rc = toAuth(*inpPtr, inpSize, args, hashFunct->crypto_md_funct,
-			    outBuff, outBuffSize);
+		rc = toAuth(*inpPtr, inpSize, args, hashFunct->crypto_md_funct, outBuff,
+			    outBuffSize);
 	else if (args->outForm[0] == 'x')
-		rc = toHashForSecVarSigning(*inpPtr, inpSize, args, outBuff,
-					    outBuffSize);
+		rc = toHashForSecVarSigning(*inpPtr, inpSize, args, outBuff, outBuffSize);
 	else
-		rc = toPKCS7ForSecVar(*inpPtr, inpSize, args,
-				      hashFunct->crypto_md_funct, outBuff,
+		rc = toPKCS7ForSecVar(*inpPtr, inpSize, args, hashFunct->crypto_md_funct, outBuff,
 				      outBuffSize);
 
 	if (rc) {
-		prlog(PR_ERR,
-		      "Failed to generate %s file, use `--help` for more info\n",
+		prlog(PR_ERR, "Failed to generate %s file, use `--help` for more info\n",
 		      args->outForm[0] == 'a' ? "Auth" :
 		      args->outForm[0] == 'x' ? "pre-signed hash" :
 						      "PKCS7");
@@ -591,10 +550,9 @@ out:
  *@param outBuffSize, the length of outBuff
  *@return SUCCESS or err number 
  */
-static int generateESL(const unsigned char *buff, size_t size,
-		       struct Arguments *args,
-		       const struct hash_funct *hashFunct,
-		       unsigned char **outBuff, size_t *outBuffSize)
+static int generateESL(const unsigned char *buff, size_t size, struct Arguments *args,
+		       const struct hash_funct *hashFunct, unsigned char **outBuff,
+		       size_t *outBuffSize)
 {
 	int rc;
 	size_t intermediateBuffSize, inpSize = size;
@@ -604,10 +562,8 @@ static int generateESL(const unsigned char *buff, size_t size,
 
 	switch (args->inForm[0]) {
 	case 'f':
-		rc = crypto_md_generate_hash(buff, size,
-					     hashFunct->crypto_md_funct,
-					     &intermediateBuff,
-					     &intermediateBuffSize);
+		rc = crypto_md_generate_hash(buff, size, hashFunct->crypto_md_funct,
+					     &intermediateBuff, &intermediateBuffSize);
 		if (rc) {
 			prlog(PR_ERR, "Failed to generate hash from file\n");
 			break;
@@ -620,8 +576,7 @@ static int generateESL(const unsigned char *buff, size_t size,
 		if (!args->inpValid) {
 			rc = validateHashAndAlg(inpSize, hashFunct);
 			if (rc) {
-				prlog(PR_ERR,
-				      "Failed to validate input hash data\n");
+				prlog(PR_ERR, "Failed to validate input hash data\n");
 				break;
 			}
 		}
@@ -631,19 +586,17 @@ static int generateESL(const unsigned char *buff, size_t size,
 	case 'c':
 		// two intermediate buffers needed, one for input -> DER and one for DER -> ESL,
 		prlog(PR_INFO, "Converting x509 from PEM to DER...\n");
-		rc = crypto_convert_pem_to_der(
-			*inpPtr, inpSize, (unsigned char **)&intermediateBuff,
-			&intermediateBuffSize);
+		rc = crypto_convert_pem_to_der(*inpPtr, inpSize,
+					       (unsigned char **)&intermediateBuff,
+					       &intermediateBuffSize);
 		if (rc) {
 			prlog(PR_ERR, "ERROR: Could not convert PEM to DER\n");
 			break;
 		}
 		if (!args->inpValid) {
-			rc = validateCert(intermediateBuff,
-					  intermediateBuffSize, args->varName);
+			rc = validateCert(intermediateBuff, intermediateBuffSize, args->varName);
 			if (rc) {
-				prlog(PR_ERR,
-				      "ERROR: Could not validate certificate\n");
+				prlog(PR_ERR, "ERROR: Could not validate certificate\n");
 				break;
 			}
 		}
@@ -657,8 +610,7 @@ static int generateESL(const unsigned char *buff, size_t size,
 		if (!args->inpValid) {
 			rc = validateAuth(buff, size, args->varName);
 			if (rc) {
-				prlog(PR_ERR,
-				      "ERROR: Could not validate signed auth file\n");
+				prlog(PR_ERR, "ERROR: Could not validate signed auth file\n");
 				break;
 			}
 		}
@@ -700,9 +652,8 @@ out:
  *@param outHashSize, the length of outHash
  *@return SUCCESS or err number 
  */
-static int generateHash(const unsigned char *data, size_t size,
-			struct Arguments *args, const struct hash_funct *alg,
-			unsigned char **outHash, size_t *outHashSize)
+static int generateHash(const unsigned char *data, size_t size, struct Arguments *args,
+			const struct hash_funct *alg, unsigned char **outHash, size_t *outHashSize)
 {
 	int rc;
 	//  if the input is not declared valid then we validate it is the same as inForm format
@@ -735,8 +686,7 @@ static int generateHash(const unsigned char *data, size_t size,
 			return rc;
 		}
 	}
-	rc = crypto_md_generate_hash(data, size, alg->crypto_md_funct, outHash,
-				     outHashSize);
+	rc = crypto_md_generate_hash(data, size, alg->crypto_md_funct, outHash, outHashSize);
 	if (rc) {
 		prlog(PR_ERR, "Failed to generate hash\n");
 		return rc;
@@ -770,8 +720,8 @@ static int validateHashAndAlg(size_t size, const struct hash_funct *alg)
  *@param outESLSize, the length of outBuff
  *@return SUCCESS or err number 
  */
-static int toESL(const unsigned char *data, size_t size, const uuid_t guid,
-		 unsigned char **outESL, size_t *outESLSize)
+static int toESL(const unsigned char *data, size_t size, const uuid_t guid, unsigned char **outESL,
+		 size_t *outESLSize)
 {
 	EFI_SIGNATURE_LIST esl;
 	size_t offset = 0;
@@ -823,16 +773,14 @@ static int toESL(const unsigned char *data, size_t size, const uuid_t guid,
  *NOTE: This allocates memory for output buffer, FREE LATER
  *@return SUCCESS or error number
  */
-static int authToESL(const unsigned char *in, size_t inSize,
-		     unsigned char **out, size_t *outSize)
+static int authToESL(const unsigned char *in, size_t inSize, unsigned char **out, size_t *outSize)
 {
 	size_t length, auth_buffer_size, offset = 0, pkcs7_size;
 	const struct efi_variable_authentication_2 *auth;
 
 	auth = (struct efi_variable_authentication_2 *)in;
 	length = auth->auth_info.hdr.dw_length;
-	if (length <= 0 ||
-	    length > inSize) { // if total size of header and pkcs7
+	if (length <= 0 || length > inSize) { // if total size of header and pkcs7
 		prlog(PR_ERR, "ERROR: Invalid auth size %zd\n", length);
 		return AUTH_FAIL;
 	}
@@ -847,8 +795,7 @@ static int authToESL(const unsigned char *in, size_t inSize,
 	 * efi_var_2->auth_info.data = auth descriptor + new ESL data.
 	 * We want only only the auth descriptor/pkcs7 from .data.
 	 */
-	auth_buffer_size = sizeof(auth->timestamp) +
-			   sizeof(auth->auth_info.hdr) +
+	auth_buffer_size = sizeof(auth->timestamp) + sizeof(auth->auth_info.hdr) +
 			   sizeof(auth->auth_info.cert_type) + pkcs7_size;
 	if (auth_buffer_size > inSize) { // If no ESL DATA attatched
 		prlog(PR_ERR, "ERROR: No data to verify, no attatched ESL\n");
@@ -878,18 +825,15 @@ static int authToESL(const unsigned char *in, size_t inSize,
  */
 static int getHashFunction(const char *name, struct hash_funct **returnFunct)
 {
-	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct);
-	     i++) {
+	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct); i++) {
 		if (!strcmp(name, hash_functions[i].name)) {
 			*returnFunct = (struct hash_funct *)&hash_functions[i];
 			return SUCCESS;
 		}
 	}
-	prlog(PR_ERR, "ERROR: Invalid hash algorithm %s , hint: use -h { ",
-	      name);
+	prlog(PR_ERR, "ERROR: Invalid hash algorithm %s , hint: use -h { ", name);
 	// loop through all known hashes
-	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct);
-	     i++) {
+	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct); i++) {
 		if (i == sizeof(hash_functions) / sizeof(struct hash_funct) - 1)
 			prlog(PR_ERR, "%s }\n", hash_functions[i].name);
 		else
@@ -940,8 +884,7 @@ static int getTimestamp(struct efi_time *ts)
  *@param outBuffSize, the length of hashed data (should be 32 bytes)
  *@return SUCCESS or err number 
  */
-static int toHashForSecVarSigning(const unsigned char *ESL, size_t ESL_size,
-				  struct Arguments *args,
+static int toHashForSecVarSigning(const unsigned char *ESL, size_t ESL_size, struct Arguments *args,
 				  unsigned char **outBuff, size_t *outBuffSize)
 {
 	int rc;
@@ -953,15 +896,13 @@ static int toHashForSecVarSigning(const unsigned char *ESL, size_t ESL_size,
 		prlog(PR_ERR, "Failed to generate pre-hash data\n");
 		goto out;
 	}
-	rc = crypto_md_generate_hash(preHash, preHash_size, CRYPTO_MD_SHA256,
-				     outBuff, outBuffSize);
+	rc = crypto_md_generate_hash(preHash, preHash_size, CRYPTO_MD_SHA256, outBuff, outBuffSize);
 	if (rc) {
 		prlog(PR_ERR, "Failed to generate hash\n");
 		goto out;
 	}
 	if (*outBuffSize != 32) {
-		prlog(PR_ERR,
-		      "ERROR: size of SHA256 is not 32 bytes, found %zd bytes\n",
+		prlog(PR_ERR, "ERROR: size of SHA256 is not 32 bytes, found %zd bytes\n",
 		      *outBuffSize);
 		rc = HASH_FAIL;
 	}
@@ -1005,9 +946,8 @@ static char *char_to_wchar(const char *key, const size_t keylen)
  *@param args, struct containing imprtant metadata info
  *@return, success or error number
  */
-static int getPreHashForSecVar(unsigned char **outData, size_t *outSize,
-			       const unsigned char *ESL, size_t ESL_size,
-			       struct Arguments *args)
+static int getPreHashForSecVar(unsigned char **outData, size_t *outSize, const unsigned char *ESL,
+			       size_t ESL_size, struct Arguments *args)
 {
 	int rc = SUCCESS;
 	unsigned char *ptr = NULL;
@@ -1017,8 +957,7 @@ static int getPreHashForSecVar(unsigned char **outData, size_t *outSize,
 	uuid_t guid;
 
 	if (!args->varName) {
-		prlog(PR_ERR,
-		      "ERROR: No secure variable name given... use -n <varName> option\n");
+		prlog(PR_ERR, "ERROR: No secure variable name given... use -n <varName> option\n");
 		rc = ARG_PARSE_FAIL;
 		goto out;
 	}
@@ -1031,12 +970,10 @@ static int getPreHashForSecVar(unsigned char **outData, size_t *outSize,
 	// some parts taken from edk2-compat-process.c
 	if (key_equals(args->varName, "PK") || key_equals(args->varName, "KEK"))
 		guid = EFI_GLOBAL_VARIABLE_GUID;
-	else if (key_equals(args->varName, "db") ||
-		 key_equals(args->varName, "dbx"))
+	else if (key_equals(args->varName, "db") || key_equals(args->varName, "dbx"))
 		guid = EFI_IMAGE_SECURITY_DATABASE_GUID;
 	else {
-		prlog(PR_ERR, "ERROR: unknown update variable %s\n",
-		      args->varName);
+		prlog(PR_ERR, "ERROR: unknown update variable %s\n", args->varName);
 		rc = ARG_PARSE_FAIL;
 		goto out;
 	}
@@ -1045,8 +982,7 @@ static int getPreHashForSecVar(unsigned char **outData, size_t *outSize,
 	varlen = strlen(args->varName) * 2;
 	wkey = char_to_wchar(args->varName, strlen(args->varName));
 	// with timestamp and all this funky bussiniss, we can  make the correct data to be hashed
-	*outSize = varlen + sizeof(guid) + sizeof(attr) +
-		   sizeof(struct efi_time) + ESL_size;
+	*outSize = varlen + sizeof(guid) + sizeof(attr) + sizeof(struct efi_time) + ESL_size;
 	*outData = malloc(*outSize);
 	if (!*outData) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
@@ -1080,16 +1016,14 @@ out:
  *@param outBuffSize, the length of outBuff
  *@return SUCCESS or err number 
  */
-static int toPKCS7ForSecVar(const unsigned char *newData, size_t dataSize,
-			    struct Arguments *args, int hashFunct,
-			    unsigned char **outBuff, size_t *outBuffSize)
+static int toPKCS7ForSecVar(const unsigned char *newData, size_t dataSize, struct Arguments *args,
+			    int hashFunct, unsigned char **outBuff, size_t *outBuffSize)
 {
 	int rc;
 	size_t totalSize;
 	unsigned char *actualData = NULL;
 
-	rc = getPreHashForSecVar(&actualData, &totalSize, newData, dataSize,
-				 args);
+	rc = getPreHashForSecVar(&actualData, &totalSize, newData, dataSize, args);
 	if (rc) {
 		prlog(PR_ERR, "Failed to generate pre-hash data for PKCS7\n");
 		goto out;
@@ -1098,14 +1032,13 @@ static int toPKCS7ForSecVar(const unsigned char *newData, size_t dataSize,
 	if (args->pkcs7_gen_meth) {
 		prlog(PR_INFO, "Generating PKCS7 with already signed data\n");
 		rc = crypto_pkcs7_generate_w_already_signed_data(
-			(unsigned char **)outBuff, outBuffSize, actualData,
-			totalSize, args->signCerts, args->signKeys,
-			args->signKeyCount, CRYPTO_MD_SHA256);
+			(unsigned char **)outBuff, outBuffSize, actualData, totalSize,
+			args->signCerts, args->signKeys, args->signKeyCount, CRYPTO_MD_SHA256);
 	} else
-		rc = crypto_pkcs7_generate_w_signature(
-			(unsigned char **)outBuff, outBuffSize, actualData,
-			totalSize, args->signCerts, args->signKeys,
-			args->signKeyCount, CRYPTO_MD_SHA256);
+		rc = crypto_pkcs7_generate_w_signature((unsigned char **)outBuff, outBuffSize,
+						       actualData, totalSize, args->signCerts,
+						       args->signKeys, args->signKeyCount,
+						       CRYPTO_MD_SHA256);
 	if (rc) {
 		prlog(PR_ERR, "ERROR: making PKCS7 failed\n");
 		rc = PKCS7_FAIL;
@@ -1129,9 +1062,8 @@ out:
  *@param outBuffSize, the length of outBuff
  *@return SUCCESS or err number 
  */
-static int toAuth(const unsigned char *newESL, size_t eslSize,
-		  struct Arguments *args, int hashFunct,
-		  unsigned char **outBuff, size_t *outBuffSize)
+static int toAuth(const unsigned char *newESL, size_t eslSize, struct Arguments *args,
+		  int hashFunct, unsigned char **outBuff, size_t *outBuffSize)
 {
 	int rc;
 	size_t pkcs7Size, offset = 0;
@@ -1139,20 +1071,16 @@ static int toAuth(const unsigned char *newESL, size_t eslSize,
 	struct efi_variable_authentication_2 authHeader;
 
 	// generate PKCS7
-	rc = toPKCS7ForSecVar(newESL, eslSize, args, hashFunct, &pkcs7,
-			      &pkcs7Size);
+	rc = toPKCS7ForSecVar(newESL, eslSize, args, hashFunct, &pkcs7, &pkcs7Size);
 	if (rc) {
-		prlog(PR_ERR,
-		      "Cannot generate Auth File, failed to generate PKCS7\n");
+		prlog(PR_ERR, "Cannot generate Auth File, failed to generate PKCS7\n");
 		goto out;
 	}
 	//  create Auth header
 	authHeader.timestamp = *args->time;
-	authHeader.auth_info.hdr.dw_length =
-		sizeof(authHeader.auth_info.hdr) +
-		sizeof(authHeader.auth_info.cert_type) + pkcs7Size;
-	authHeader.auth_info.hdr.w_revision =
-		cpu_to_be16(WIN_CERT_TYPE_PKCS_SIGNED_DATA);
+	authHeader.auth_info.hdr.dw_length = sizeof(authHeader.auth_info.hdr) +
+					     sizeof(authHeader.auth_info.cert_type) + pkcs7Size;
+	authHeader.auth_info.hdr.w_revision = cpu_to_be16(WIN_CERT_TYPE_PKCS_SIGNED_DATA);
 	// ranges from f0 -ff, but all files Ive seen have f10e
 	authHeader.auth_info.hdr.w_certificate_type = cpu_to_be16(0xf10e);
 	authHeader.auth_info.cert_type = EFI_CERT_TYPE_PKCS7_GUID;
@@ -1174,8 +1102,7 @@ static int toAuth(const unsigned char *newESL, size_t eslSize,
 	prlog(PR_INFO, "\t+ PKCS7 %zd bytes\n", pkcs7Size);
 	memcpy(*outBuff + offset, newESL, eslSize);
 	offset += eslSize;
-	prlog(PR_INFO, "\t+ new ESL %zd bytes\n\t= %zd total bytes\n", eslSize,
-	      offset);
+	prlog(PR_INFO, "\t+ new ESL %zd bytes\n\t= %zd total bytes\n", eslSize, offset);
 
 out:
 	if (pkcs7)

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -13,11 +13,9 @@
 #include "external/skiboot/libstb/secvar/secvar.h" // for secvar struct
 #include "backends/edk2-compat/include/edk2-svc.h" // include last, pragma pack(1) issue
 
-static int readFiles(const char *var, const char *file, int hrFlag,
-		     const char *path);
+static int readFiles(const char *var, const char *file, int hrFlag, const char *path);
 static int printReadable(const char *c, size_t size, const char *key);
-static int readFileFromSecVar(const char *path, const char *variable,
-			      int hrFlag);
+static int readFileFromSecVar(const char *path, const char *variable, int hrFlag);
 static int readFileFromPath(const char *path, int hrFlag);
 static int getSizeFromSizeFile(size_t *returnSize, const char *path);
 static int readTS(const char *data, size_t size);
@@ -38,26 +36,20 @@ static int parse_opt(int key, char *arg, struct argp_state *state);
 int performReadCommand(int argc, char *argv[])
 {
 	int rc;
-	struct Arguments args = { .helpFlag = 0,
-				  .printRaw = 0,
-				  .pathToSecVars = NULL,
-				  .inFile = NULL,
-				  .varName = NULL };
+	struct Arguments args = {
+		.helpFlag = 0, .printRaw = 0, .pathToSecVars = NULL, .inFile = NULL, .varName = NULL
+	};
 	// combine command and subcommand for usage/help messages
 	argv[0] = "secvarctl read";
 
 	struct argp_option options[] = {
-		{ "raw", 'r', 0, 0,
-		  "prints raw data, default is human readable information" },
-		{ "verbose", 'v', 0, 0,
-		  "print more verbose process information" },
-		{ "file", 'f', "FILE", 0,
-		  "navigates to ESL file from working directiory" },
+		{ "raw", 'r', 0, 0, "prints raw data, default is human readable information" },
+		{ "verbose", 'v', 0, 0, "print more verbose process information" },
+		{ "file", 'f', "FILE", 0, "navigates to ESL file from working directiory" },
 		{ "path", 'p', "PATH", 0,
 		  "looks for key directories {'PK','KEK','db','dbx', 'TS'} in PATH, default is " SECVARPATH },
 		{ "help", '?', 0, 0, "Give this help list", 1 },
-		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0,
-		  "Give a short usage message", -1 },
+		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{ 0 }
 	};
 
@@ -70,13 +62,11 @@ int performReadCommand(int argc, char *argv[])
 		" then the '-f' command would be appropriate."
 		"\vvalues for [VARIABLES] = {'PK','KEK','db','dbx', 'TS'} type one of the following to get info on that key, default is all. NOTE does not work when -f option is present"
 	};
-	rc = argp_parse(&argp, argc, argv,
-			ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
+	rc = argp_parse(&argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag)
 		goto out;
 
-	rc = readFiles(args.varName, args.inFile, !args.printRaw,
-		       args.pathToSecVars);
+	rc = readFiles(args.varName, args.inFile, !args.printRaw, args.pathToSecVars);
 
 out:
 	return rc;
@@ -118,8 +108,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		args->varName = arg;
 		rc = isVariable(args->varName);
 		if (rc)
-			prlog(PR_ERR, "ERROR: Invalid variable name %s\n",
-			      args->varName);
+			prlog(PR_ERR, "ERROR: Invalid variable name %s\n", args->varName);
 		break;
 	}
 
@@ -137,8 +126,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
  *@param path string to path where {PK,KEK,db,dbx,TS} subdirectories are, default SECVARPATH if none given
  *@return succcess if at least one file was successfully read
  */
-static int readFiles(const char *var, const char *file, int hrFlag,
-		     const char *path)
+static int readFiles(const char *var, const char *file, int hrFlag, const char *path)
 {
 	// program is successful if at least one var was able to be read
 	int rc, successCount = 0;
@@ -146,10 +134,8 @@ static int readFiles(const char *var, const char *file, int hrFlag,
 	if (file)
 		prlog(PR_NOTICE, "Looking in file %s for ESL's\n", file);
 	else
-		prlog(PR_NOTICE,
-		      "Looking in %s for %s variable with %s format\n",
-		      path ? path : SECVARPATH, var ? var : "ALL",
-		      hrFlag ? "ASCII" : "raw_data");
+		prlog(PR_NOTICE, "Looking in %s for %s variable with %s format\n",
+		      path ? path : SECVARPATH, var ? var : "ALL", hrFlag ? "ASCII" : "raw_data");
 
 	// set default path if no path chosen
 	if (!path) {
@@ -188,8 +174,7 @@ static int readFiles(const char *var, const char *file, int hrFlag,
  *@param hrFlag, 1 for human readable 0 for raw data
  *@return SUCCESS or error number
  */
-static int readFileFromSecVar(const char *path, const char *variable,
-			      int hrFlag)
+static int readFileFromSecVar(const char *path, const char *variable, int hrFlag)
 {
 	int extra = 10, rc;
 	struct secvar *var = NULL;
@@ -222,8 +207,7 @@ static int readFileFromSecVar(const char *path, const char *variable,
 			rc = printReadable(var->data, var->data_size, var->key);
 
 		if (rc)
-			prlog(PR_WARNING,
-			      "ERROR: Could not parse file, continuing...\n");
+			prlog(PR_WARNING, "ERROR: Could not parse file, continuing...\n");
 	} else {
 		printRaw(var->data, var->data_size);
 		rc = SUCCESS;
@@ -296,8 +280,7 @@ int getSecVar(struct secvar **var, const char *name, const char *fullPath)
 	strncat(sizePath, "size", strlen("size") + 1);
 	rc = getSizeFromSizeFile(&size, sizePath);
 	if (rc < 0) {
-		prlog(PR_WARNING,
-		      "ERROR: Could not get size of variable, TIP: does %s exist?\n",
+		prlog(PR_WARNING, "ERROR: Could not get size of variable, TIP: does %s exist?\n",
 		      sizePath);
 		rc = INVALID_FILE;
 		free(sizePath);
@@ -306,16 +289,15 @@ int getSecVar(struct secvar **var, const char *name, const char *fullPath)
 	free(sizePath);
 
 	if (size == 0) {
-		prlog(PR_WARNING,
-		      "Secure Variable has size of zero, (specified by size file)\n");
+		prlog(PR_WARNING, "Secure Variable has size of zero, (specified by size file)\n");
 		/*rc = INVALID_FILE;
 		return rc;*/
 	}
 
 	fptr = open(fullPath, O_RDONLY);
 	if (fptr < 0) {
-		prlog(PR_WARNING, "-----opening %s failed: %s-------\n\n",
-		      fullPath, strerror(errno));
+		prlog(PR_WARNING, "-----opening %s failed: %s-------\n\n", fullPath,
+		      strerror(errno));
 		return INVALID_FILE;
 	}
 	if (fstat(fptr, &fileInfo) < 0) {
@@ -323,13 +305,11 @@ int getSecVar(struct secvar **var, const char *name, const char *fullPath)
 	}
 	// if file size is less than expeced size, error
 	if (fileInfo.st_size < size) {
-		prlog(PR_ERR,
-		      "ERROR: expected size (%zd) is less than actual size (%ld)\n",
-		      size, fileInfo.st_size);
+		prlog(PR_ERR, "ERROR: expected size (%zd) is less than actual size (%ld)\n", size,
+		      fileInfo.st_size);
 		return INVALID_FILE;
 	}
-	prlog(PR_NOTICE, "---opening %s is success: reading %zd bytes---- \n",
-	      fullPath, size);
+	prlog(PR_NOTICE, "---opening %s is success: reading %zd bytes---- \n", fullPath, size);
 	c = malloc(size);
 	if (!c) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
@@ -338,8 +318,7 @@ int getSecVar(struct secvar **var, const char *name, const char *fullPath)
 
 	read_size = read(fptr, c, size);
 	if (read_size != size) {
-		prlog(PR_ERR, "ERROR: did not read all data of %s in one go\n",
-		      fullPath);
+		prlog(PR_ERR, "ERROR: did not read all data of %s in one go\n", fullPath);
 		free(c);
 		close(fptr);
 		return INVALID_FILE;
@@ -388,11 +367,9 @@ static int printReadable(const char *c, size_t size, const char *key)
 		sigList = get_esl_signature_list(c + offset, eslvarsize);
 		// check size info is logical
 		if (sigList->SignatureListSize > 0) {
-			if ((sigList->SignatureSize <= 0 &&
-			     sigList->SignatureHeaderSize <= 0) ||
+			if ((sigList->SignatureSize <= 0 && sigList->SignatureHeaderSize <= 0) ||
 			    sigList->SignatureListSize <
-				    sigList->SignatureHeaderSize +
-					    sigList->SignatureSize) {
+				    sigList->SignatureHeaderSize + sigList->SignatureSize) {
 				/*printf("Sig List : %d , sig Header: %d, sig Size: %d\n",list.SignatureListSize,list.SignatureHeaderSize,list.SignatureSize);*/
 				prlog(PR_ERR,
 				      "ERROR: Sig List is not structured correctly, defined size and actual sizes are mismatched\n");
@@ -404,8 +381,7 @@ static int printReadable(const char *c, size_t size, const char *key)
 		    sigList->SignatureSize > eslvarsize) {
 			prlog(PR_ERR,
 			      "ERROR: Expected Sig List Size %d + Header size %d + Signature Size is %d larger than actual size %zd\n",
-			      sigList->SignatureListSize,
-			      sigList->SignatureHeaderSize,
+			      sigList->SignatureListSize, sigList->SignatureHeaderSize,
 			      sigList->SignatureSize, eslvarsize);
 			break;
 		}
@@ -414,8 +390,7 @@ static int printReadable(const char *c, size_t size, const char *key)
 		// puts sig data in cert
 		cert_size = get_esl_cert(c + offset, sigList, (char **)&cert);
 		if (cert_size <= 0) {
-			prlog(PR_ERR,
-			      "\tERROR: Signature Size was too small, no data \n");
+			prlog(PR_ERR, "\tERROR: Signature Size was too small, no data \n");
 			break;
 		}
 		if (key && !strcmp(key, "dbx")) {
@@ -473,8 +448,7 @@ int printCertInfo(crypto_x509 *x509)
 		return CERT_FAIL;
 	}
 	// failures = number of bytes written, x509_info now has string of ascii data
-	failures = crypto_x509_get_long_desc(x509_info, CERT_BUFFER_SIZE,
-					     "\t\t", x509);
+	failures = crypto_x509_get_long_desc(x509_info, CERT_BUFFER_SIZE, "\t\t", x509);
 	if (failures <= 0) {
 		prlog(PR_ERR,
 		      "\tERROR: Failed to get cert info, wrote %d bytes when getting info\n",
@@ -500,8 +474,7 @@ static int readTS(const char *data, size_t size)
 	if (size != sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1)) {
 		prlog(PR_ERR,
 		      "ERROR: TS variable does not contain data on all the variables, expected %ld bytes of data, found %zd\n",
-		      sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1),
-		      size);
+		      sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1), size);
 		return INVALID_TIMESTAMP;
 	}
 
@@ -509,8 +482,8 @@ static int readTS(const char *data, size_t size)
 	     tmpStamp = (void *)tmpStamp + sizeof(struct efi_time),
 	    size -= sizeof(struct efi_time)) {
 		// print variable name
-		printf("\t%s:\t", variables[(ARRAY_SIZE(variables) - 1) -
-					    (size / sizeof(struct efi_time))]);
+		printf("\t%s:\t",
+		       variables[(ARRAY_SIZE(variables) - 1) - (size / sizeof(struct efi_time))]);
 		printTimestamp(*tmpStamp);
 	}
 
@@ -528,8 +501,7 @@ ssize_t get_esl_cert(const char *c, EFI_SIGNATURE_LIST *list, char **cert)
 {
 	ssize_t size, dataOffset;
 	size = list->SignatureSize - sizeof(uuid_t);
-	dataOffset = sizeof(EFI_SIGNATURE_LIST) + list->SignatureHeaderSize +
-		     16 * sizeof(uint8_t);
+	dataOffset = sizeof(EFI_SIGNATURE_LIST) + list->SignatureHeaderSize + 16 * sizeof(uint8_t);
 	*cert = malloc(size);
 	if (!*cert) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
@@ -549,8 +521,7 @@ ssize_t get_esl_cert(const char *c, EFI_SIGNATURE_LIST *list, char **cert)
 const char *getSigType(const uuid_t type)
 {
 	// loop through all known hashes
-	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct);
-	     i++) {
+	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct); i++) {
 		if (uuid_equals(&type, hash_functions[i].guid))
 			return hash_functions[i].name;
 	}
@@ -588,8 +559,7 @@ EFI_SIGNATURE_LIST *get_esl_signature_list(const char *buf, size_t buflen)
 {
 	EFI_SIGNATURE_LIST *list = NULL;
 	if (buflen < sizeof(EFI_SIGNATURE_LIST) || !buf) {
-		prlog(PR_ERR,
-		      "ERROR: SigList does not have enough data to be valid\n");
+		prlog(PR_ERR, "ERROR: SigList does not have enough data to be valid\n");
 		return NULL;
 	}
 	list = (EFI_SIGNATURE_LIST *)buf;
@@ -612,8 +582,7 @@ static int getSizeFromSizeFile(size_t *returnSize, const char *path)
 	struct stat fileInfo;
 	fptr = open(path, O_RDONLY);
 	if (fptr < 0) {
-		prlog(PR_WARNING, "----opening %s failed : %s----\n", path,
-		      strerror(errno));
+		prlog(PR_WARNING, "----opening %s failed : %s----\n", path, strerror(errno));
 		return INVALID_FILE;
 	}
 	if (fstat(fptr, &fileInfo) < 0) {
@@ -629,8 +598,7 @@ static int getSizeFromSizeFile(size_t *returnSize, const char *path)
 		close(fptr);
 		return ALLOC_FAIL;
 	}
-	prlog(PR_NOTICE,
-	      "----opening %s is success: reading %zd of %zd bytes----\n", path,
+	prlog(PR_NOTICE, "----opening %s is success: reading %zd of %zd bytes----\n", path,
 	      maxdigits, fileInfo.st_size);
 	read_size = read(fptr, c, maxdigits);
 	if (read_size <= 0) {

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -548,25 +548,6 @@ void printGuidSig(const void *sig)
 	printf("\n");
 }
 
-/**
- *parses buffer into a EFI_SIG_LIST
- *@param buf pointer to sig list buffer
- *@param buflen length of buffer
- *@return NULL if buflen is smaller than size of sig list stuct or if buff is empty
- *@return EFI_SIG_LIST struct
- */
-EFI_SIGNATURE_LIST *get_esl_signature_list(const char *buf, size_t buflen)
-{
-	EFI_SIGNATURE_LIST *list = NULL;
-	if (buflen < sizeof(EFI_SIGNATURE_LIST) || !buf) {
-		prlog(PR_ERR, "ERROR: SigList does not have enough data to be valid\n");
-		return NULL;
-	}
-	list = (EFI_SIGNATURE_LIST *)buf;
-
-	return list;
-}
-
 /*
  *gets the integer value from the ascii file "size"
  *@param size, the returned size of size file

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -11,7 +11,7 @@
 #include <argp.h>
 #include "libstb/secvar/crypto/crypto.h"
 #include "external/skiboot/libstb/secvar/secvar.h" // for secvar struct
-#include "backends/edk2-compat/include/edk2-svc.h" // include last, pragma pack(1) issue
+#include "backends/edk2-compat/include/edk2-svc.h"
 
 static int readFiles(const char *var, const char *file, int hrFlag, const char *path);
 static int printReadable(const char *c, size_t size, const char *key);

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -388,7 +388,7 @@ static int printReadable(const char *c, size_t size, const char *key)
 		eslsize = sigList->SignatureListSize;
 		printESLInfo(sigList);
 		// puts sig data in cert
-		cert_size = get_esl_cert(c + offset, sigList, (char **)&cert);
+		cert_size = get_esl_cert(c + offset, eslvarsize, (char **)&cert);
 		if (cert_size <= 0) {
 			prlog(PR_ERR, "\tERROR: Signature Size was too small, no data \n");
 			break;
@@ -488,29 +488,6 @@ static int readTS(const char *data, size_t size)
 	}
 
 	return SUCCESS;
-}
-
-/** 
- *inspired by secvar/backend/edk2-compat-process.c by Nayna Jain
- *@param c  pointer to start of esl file
- *@param cert empty buffer 
- *@param list current siglist
- *@return size of memory allocated to cert or negative number if allocation fails
- */
-ssize_t get_esl_cert(const char *c, EFI_SIGNATURE_LIST *list, char **cert)
-{
-	ssize_t size, dataOffset;
-	size = list->SignatureSize - sizeof(uuid_t);
-	dataOffset = sizeof(EFI_SIGNATURE_LIST) + list->SignatureHeaderSize + 16 * sizeof(uint8_t);
-	*cert = malloc(size);
-	if (!*cert) {
-		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
-		return ALLOC_FAIL;
-	}
-	// copies size bytes from eslfile-headerstuff and guid into cert
-	memcpy(*cert, c + dataOffset, size);
-
-	return size;
 }
 
 /**

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -15,16 +15,11 @@ struct Arguments {
 
 static bool validate_hash(uuid_t type, size_t size);
 static int parse_opt(int key, char *arg, struct argp_state *state);
-static int validateSingularESL(size_t *bytesRead, const unsigned char *esl,
-			       size_t eslvarsize, const char *varName);
+static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size_t eslvarsize,
+			       const char *varName);
 static int validateCertStruct(crypto_x509 *x509, const char *varName);
 
-enum fileTypes {
-	AUTH_FILE = 'a',
-	PKCS7_FILE = 'p',
-	ESL_FILE = 'e',
-	CERT_FILE = 'c'
-};
+enum fileTypes { AUTH_FILE = 'a', PKCS7_FILE = 'p', ESL_FILE = 'e', CERT_FILE = 'c' };
 
 /*
  *called from main()
@@ -38,27 +33,23 @@ int performValidation(int argc, char *argv[])
 	unsigned char *buff = NULL;
 	size_t size;
 	int rc;
-	struct Arguments args = { .helpFlag = 0,
-				  .inFile = NULL,
-				  .inForm = AUTH_FILE,
-				  .varName = NULL };
+	struct Arguments args = {
+		.helpFlag = 0, .inFile = NULL, .inForm = AUTH_FILE, .varName = NULL
+	};
 	// combine command and subcommand for usage/help messages
 	argv[0] = "secvarctl validate";
 
 	struct argp_option options[] = {
-		{ "verbose", 'v', 0, 0,
-		  "print more verbose process information" },
+		{ "verbose", 'v', 0, 0, "print more verbose process information" },
 		{ "pkcs7", 'p', 0, 0, "file is a PKCS7" },
 		{ "esl", 'e', 0, 0, "file is an EFI Signature List (ESL)" },
-		{ "cert", 'c', 0, 0,
-		  "file is an x509 cert (DER or PEM format)" },
+		{ "cert", 'c', 0, 0, "file is an x509 cert (DER or PEM format)" },
 		{ "auth", 'a', 0, 0,
 		  "file is a properly generated authenticated variable, DEFAULT" },
 		{ "dbx", 'x', 0, 0,
 		  "file is for the dbx (allows for data to contain a hash not an x509), Note: user still should specify the file type" },
 		{ "help", '?', 0, 0, "Give this help list", 1 },
-		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0,
-		  "Give a short usage message", -1 },
+		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{ 0 }
 	};
 
@@ -69,15 +60,13 @@ int performValidation(int argc, char *argv[])
 		" use 'secvarctl verify' to see if content and file signature (if PKCS7/auth) are valid"
 	};
 
-	rc = argp_parse(&argp, argc, argv,
-			ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
+	rc = argp_parse(&argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag)
 		goto out;
 
 	buff = (unsigned char *)getDataFromFile(args.inFile, &size);
 	if (!buff) {
-		prlog(PR_ERR, "ERROR: failed to get data from %s\n",
-		      args.inFile);
+		prlog(PR_ERR, "ERROR: failed to get data from %s\n", args.inFile);
 		rc = INVALID_FILE;
 		goto out;
 	}
@@ -154,8 +143,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		if (args->helpFlag)
 			break;
 		if (!args->inFile)
-			prlog(PR_ERR,
-			      "ERROR: missing input file, see usage...\n");
+			prlog(PR_ERR, "ERROR: missing input file, see usage...\n");
 		else
 			break;
 		argp_usage(state);
@@ -191,8 +179,7 @@ int validateAuth(const unsigned char *authBuf, size_t buflen, const char *key)
 	}
 
 	if (buflen < sizeof(struct efi_variable_authentication_2)) {
-		prlog(PR_ERR,
-		      "ERROR: auth file is too small to be valid auth file\n");
+		prlog(PR_ERR, "ERROR: auth file is too small to be valid auth file\n");
 		return AUTH_FAIL;
 	}
 
@@ -200,9 +187,8 @@ int validateAuth(const unsigned char *authBuf, size_t buflen, const char *key)
 	authSize = auth->auth_info.hdr.dw_length + sizeof(auth->timestamp);
 	// if expected length is greater than the actual length or not a valid size, return fail
 	if ((ssize_t)authSize <= 0 || authSize > buflen) {
-		prlog(PR_ERR,
-		      "ERROR: Invalid auth size, expected %zd found %zd\n",
-		      authSize, buflen);
+		prlog(PR_ERR, "ERROR: Invalid auth size, expected %zd found %zd\n", authSize,
+		      buflen);
 		return AUTH_FAIL;
 	}
 
@@ -242,8 +228,7 @@ int validateAuth(const unsigned char *authBuf, size_t buflen, const char *key)
 	// now validate appended ESL
 	// if no ESL appended then print warning and continue, could be a delete key update
 	if (authSize == buflen) {
-		prlog(PR_WARNING,
-		      "WARNING: appended ESL is empty, (valid key reset file)...\n");
+		prlog(PR_WARNING, "WARNING: appended ESL is empty, (valid key reset file)...\n");
 	} else {
 		rc = validateESL(authBuf + authSize, buflen - authSize, key);
 		if (rc) {
@@ -268,10 +253,9 @@ size_t get_pkcs7_len(const struct efi_variable_authentication_2 *auth)
 		return 0;
 	}
 	dw_length = auth->auth_info.hdr.dw_length;
-	size = dw_length - (sizeof(auth->auth_info.hdr.dw_length) +
-			    sizeof(auth->auth_info.hdr.w_revision) +
-			    sizeof(auth->auth_info.hdr.w_certificate_type) +
-			    sizeof(auth->auth_info.cert_type));
+	size = dw_length -
+	       (sizeof(auth->auth_info.hdr.dw_length) + sizeof(auth->auth_info.hdr.w_revision) +
+		sizeof(auth->auth_info.hdr.w_certificate_type) + sizeof(auth->auth_info.cert_type));
 
 	return size;
 }
@@ -311,8 +295,7 @@ int validatePKCS7(const unsigned char *cert_data, size_t len)
 		else
 			rc = CERT_FAIL;
 		if (rc) {
-			prlog(PR_ERR,
-			      "ERROR: failure to parse x509 signing certificate\n");
+			prlog(PR_ERR, "ERROR: failure to parse x509 signing certificate\n");
 			goto out;
 		}
 
@@ -345,13 +328,10 @@ int validateESL(const unsigned char *eslBuf, size_t buflen, const char *key)
 	int count = 0, offset = 0, rc;
 	prlog(PR_INFO, "VALIDATING ESL:\n");
 	while (eslvarsize > 0) {
-		rc = validateSingularESL(&eslsize, eslBuf + offset, eslvarsize,
-					 key);
+		rc = validateSingularESL(&eslsize, eslBuf + offset, eslvarsize, key);
 		// verify current esl to ensure it is a valid sigList, if 1 is returned break or error
 		if (rc) {
-			prlog(PR_ERR,
-			      "ERROR: Sig List #%d is not structured correctly\n",
-			      count);
+			prlog(PR_ERR, "ERROR: Sig List #%d is not structured correctly\n", count);
 			// if there is one good esl just leave the loop
 			if (count)
 				break;
@@ -381,8 +361,8 @@ int validateESL(const unsigned char *eslBuf, size_t buflen, const char *key)
  *@param varName, variable name {"db","dbx","KEK", "PK"} b/c dbx is a different format
  *@return SUCCESS if cetificate and header info is valid, errno otherwise
  */
-static int validateSingularESL(size_t *bytesRead, const unsigned char *esl,
-			       size_t eslvarsize, const char *varName)
+static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size_t eslvarsize,
+			       const char *varName)
 {
 	ssize_t cert_size;
 	int rc;
@@ -402,11 +382,9 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl,
 	sigList = get_esl_signature_list((const char *)esl, eslvarsize);
 	// check size info is logical
 	if (sigList->SignatureListSize > 0) {
-		if ((sigList->SignatureSize <= 0 &&
-		     sigList->SignatureHeaderSize <= 0) ||
+		if ((sigList->SignatureSize <= 0 && sigList->SignatureHeaderSize <= 0) ||
 		    sigList->SignatureListSize <
-			    sigList->SignatureHeaderSize +
-				    sigList->SignatureSize) {
+			    sigList->SignatureHeaderSize + sigList->SignatureSize) {
 			/*printf("Sig List : %d , sig Header: %d, sig Size: %d\n",list.SignatureListSize,list.SignatureHeaderSize,list.SignatureSize);*/
 			prlog(PR_ERR,
 			      "ERROR: Sig List is not structured correctly, defined size and actual sizes are mismatched\n");
@@ -415,8 +393,7 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl,
 	}
 	if (verbose >= PR_INFO)
 		printESLInfo(sigList);
-	if (sigList->SignatureListSize > eslvarsize ||
-	    sigList->SignatureHeaderSize > eslvarsize ||
+	if (sigList->SignatureListSize > eslvarsize || sigList->SignatureHeaderSize > eslvarsize ||
 	    sigList->SignatureSize > eslvarsize) {
 		prlog(PR_ERR,
 		      "ERROR: Expected Sig List Size %d + Header size %d + Signature Size is %d larger than actual size %zd\n",
@@ -439,8 +416,7 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl,
 
 	// if dbx expect some type of SHA
 	if (varName && !strcmp(varName, "dbx")) {
-		if (strncmp(getSigType(sigList->SignatureType), "SHA", 3) !=
-		    0) {
+		if (strncmp(getSigType(sigList->SignatureType), "SHA", 3) != 0) {
 			prlog(PR_ERR,
 			      "ERROR: dbx has wrong guid type, expected a SHA function found %s\n",
 			      getSigType(sigList->SignatureType));
@@ -456,8 +432,7 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl,
 	cert_size = get_esl_cert((const char *)esl, sigList,
 				 (char **)&cert); // puts sig data in cert
 	if (cert_size <= 0) {
-		prlog(PR_ERR,
-		      "\tERROR: Signature Size was too small, no data \n");
+		prlog(PR_ERR, "\tERROR: Signature Size was too small, no data \n");
 		return ESL_FAIL;
 	}
 	// if dbx, make sure it is 32 bytes if SHA256, 64 for SHA512 etc, and skip x509 validation
@@ -487,10 +462,8 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl,
 static bool validate_hash(uuid_t type, size_t size)
 {
 	// loop through all known hashes
-	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct);
-	     i++) {
-		if (uuid_equals(&type, hash_functions[i].guid) &&
-		    (size == hash_functions[i].size))
+	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct); i++) {
+		if (uuid_equals(&type, hash_functions[i].guid) && (size == hash_functions[i].size))
 			return true;
 	}
 
@@ -505,8 +478,7 @@ static bool validate_hash(uuid_t type, size_t size)
  *@return CERT_FAIL if certificate had incorrect data
  *@return SUCCESS if certificate is valid
  */
-int validateCert(const unsigned char *certBuf, size_t buflen,
-		 const char *varName)
+int validateCert(const unsigned char *certBuf, size_t buflen, const char *varName)
 {
 	int rc;
 	crypto_x509 *x509 = NULL;
@@ -553,8 +525,7 @@ static int validateCertStruct(crypto_x509 *x509, const char *varName)
 	// check raw certificate body has TBSCertificate data
 	len = crypto_x509_get_tbs_der_len(x509);
 	if (len < 0) {
-		prlog(PR_ERR,
-		      "ERROR: Could not read length of X509 TBS Certificate\n");
+		prlog(PR_ERR, "ERROR: Could not read length of X509 TBS Certificate\n");
 		return CERT_FAIL;
 	}
 	if (len == 0) {
@@ -587,17 +558,14 @@ static int validateCertStruct(crypto_x509 *x509, const char *varName)
 	// if x509 for db then signature can be RSA 4096 or other (since it won't be signing anything else)
 	// this addresses OS's that release certificates with non RSA-2048 (ex: RHEL)
 	if (varName == NULL || strncmp(varName, "db", strlen(varName))) {
-		if (crypto_x509_md_is_sha256(x509) ||
-		    crypto_x509_oid_is_pkcs1_sha256(x509) ||
+		if (crypto_x509_md_is_sha256(x509) || crypto_x509_oid_is_pkcs1_sha256(x509) ||
 		    crypto_x509_get_pk_bit_len(x509) != 2048) {
 			x509_info = malloc(CERT_BUFFER_SIZE);
 			if (!x509_info) {
-				prlog(PR_ERR,
-				      "ERROR: failed to allocate memory\n");
+				prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 				return CERT_FAIL;
 			}
-			crypto_x509_get_short_info(x509, x509_info,
-						   CERT_BUFFER_SIZE);
+			crypto_x509_get_short_info(x509, x509_info, CERT_BUFFER_SIZE);
 			prlog(PR_ERR,
 			      "ERROR: Wanted x509 with RSA 2048 and SHA-256. Discovered %s with signature length %d bits\n",
 			      x509_info, crypto_x509_get_pk_bit_len(x509));
@@ -633,8 +601,7 @@ int parseX509(crypto_x509 **x509, const unsigned char *certBuf, size_t buflen)
 	unsigned char *generatedDER = NULL;
 	size_t generatedDERSize;
 	if ((ssize_t)buflen <= 0) {
-		prlog(PR_ERR,
-		      "ERROR: Certificate has invalid length %zd, cannot validate\n",
+		prlog(PR_ERR, "ERROR: Certificate has invalid length %zd, cannot validate\n",
 		      buflen);
 		return CERT_FAIL;
 	}
@@ -643,8 +610,7 @@ int parseX509(crypto_x509 **x509, const unsigned char *certBuf, size_t buflen)
 	if (!*x509) {
 		prlog(PR_INFO, "Failed to parse x509 as DER, trying PEM...\n");
 		// if failed, maybe input is PEM and so try converting PEM to DER, if conversion fails then we know it was DER and it failed
-		if (crypto_convert_pem_to_der(certBuf, buflen, &generatedDER,
-					      &generatedDERSize)) {
+		if (crypto_convert_pem_to_der(certBuf, buflen, &generatedDER, &generatedDERSize)) {
 			prlog(PR_ERR,
 			      "ERROR: Failed to parse x509 in DER and file is not in PEM\n");
 			return CERT_FAIL;
@@ -678,13 +644,11 @@ int validateTS(const unsigned char *data, size_t size)
 	if (size != sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1)) {
 		prlog(PR_ERR,
 		      "ERROR: TS variable does not contain data on all the variables, expected %ld bytes of data, found %zd\n",
-		      sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1),
-		      size);
+		      sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1), size);
 		return INVALID_TIMESTAMP;
 	}
 	for (pointer = (char *)data; size > 0;
-	     pointer += sizeof(struct efi_time),
-	    size -= sizeof(struct efi_time)) {
+	     pointer += sizeof(struct efi_time), size -= sizeof(struct efi_time)) {
 		tmpStamp = (struct efi_time *)pointer;
 		rc = validateTime(tmpStamp);
 		if (rc)
@@ -714,38 +678,32 @@ out:
 int validateTime(struct efi_time *time)
 {
 	if (time->year < 1900 || time->year > 9999) {
-		prlog(PR_ERR, "ERROR: Invalid Timestamp value for year: %d\n",
-		      time->year);
+		prlog(PR_ERR, "ERROR: Invalid Timestamp value for year: %d\n", time->year);
 		return INVALID_TIMESTAMP;
 	}
 
 	if (time->month < 1 || time->month > 12) {
-		prlog(PR_ERR, "ERROR: Invalid Timestamp value for month: %d\n",
-		      time->month);
+		prlog(PR_ERR, "ERROR: Invalid Timestamp value for month: %d\n", time->month);
 		return INVALID_TIMESTAMP;
 	}
 
 	if (time->day < 1 || time->day > 31) {
-		prlog(PR_ERR, "ERROR: Invalid Timestamp value for day: %d\n",
-		      time->day);
+		prlog(PR_ERR, "ERROR: Invalid Timestamp value for day: %d\n", time->day);
 		return INVALID_TIMESTAMP;
 	}
 
 	if (time->hour < 0 || time->hour > 23) {
-		prlog(PR_ERR, "ERROR: Invalid Timestamp value for hour: %d\n",
-		      time->hour);
+		prlog(PR_ERR, "ERROR: Invalid Timestamp value for hour: %d\n", time->hour);
 		return INVALID_TIMESTAMP;
 	}
 
 	if (time->minute < 0 || time->minute > 59) {
-		prlog(PR_ERR, "ERROR: Invalid Timestamp value for minute: %d\n",
-		      time->minute);
+		prlog(PR_ERR, "ERROR: Invalid Timestamp value for minute: %d\n", time->minute);
 		return INVALID_TIMESTAMP;
 	}
 
 	if (time->second < 0 || time->second > 60) {
-		prlog(PR_ERR, "ERROR: Invalid Timestamp value for second: %d\n",
-		      time->second);
+		prlog(PR_ERR, "ERROR: Invalid Timestamp value for second: %d\n", time->second);
 		return INVALID_TIMESTAMP;
 	}
 
@@ -756,6 +714,6 @@ void printTimestamp(struct efi_time t)
 {
 	// NOTE: if auth is made with sign-efi-sig-list, year will be actual year+1 (see https:// blog.hansenpartnership.com/updating-pk-kek-db-and-x-in-user-mode/),
 	// also month could be one less bc months are 0-11 not 1-12
-	printf("%04d-%02d-%02d %02d:%02d:%02d UTC\n", t.year, t.month, t.day,
-	       t.hour, t.minute, t.second);
+	printf("%04d-%02d-%02d %02d:%02d:%02d UTC\n", t.year, t.month, t.day, t.hour, t.minute,
+	       t.second);
 }

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -240,26 +240,6 @@ int validateAuth(const unsigned char *authBuf, size_t buflen, const char *key)
 	return rc;
 }
 
-// inspired by secvar/backend/edk2-compat-process.c by Nayna Jain
-/**
- *returns only size of auth->auth_info.hdr.cert_data
- *auth->auth_info.hdr.dw_length is size of .cert_data and .hdr so we remove .hdr sizes
- */
-size_t get_pkcs7_len(const struct efi_variable_authentication_2 *auth)
-{
-	uint32_t dw_length;
-	size_t size;
-	if (auth == NULL) {
-		return 0;
-	}
-	dw_length = auth->auth_info.hdr.dw_length;
-	size = dw_length -
-	       (sizeof(auth->auth_info.hdr.dw_length) + sizeof(auth->auth_info.hdr.w_revision) +
-		sizeof(auth->auth_info.hdr.w_certificate_type) + sizeof(auth->auth_info.cert_type));
-
-	return size;
-}
-
 /**
  *calls Nayna Jain's pkcs7 functions to validate the pkcs7 inside of the given auth struct
  *@param auth, pointer to auth struct data containing the pkcs7 in auth->auth_info.hdr.cert_data

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -5,7 +5,7 @@
 #include <stdlib.h> // for exit
 #include <argp.h>
 #include "libstb/secvar/crypto/crypto.h"
-#include "include/edk2-svc.h" // import last!!
+#include "include/edk2-svc.h"
 
 struct Arguments {
 	int helpFlag;

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -429,7 +429,7 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size
 		return ESL_FAIL;
 	}
 	// get certificate
-	cert_size = get_esl_cert((const char *)esl, sigList,
+	cert_size = get_esl_cert((const char *)esl, eslvarsize,
 				 (char **)&cert); // puts sig data in cert
 	if (cert_size <= 0) {
 		prlog(PR_ERR, "\tERROR: Signature Size was too small, no data \n");

--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -18,20 +18,17 @@ struct Arguments {
 
 extern struct secvar_backend_driver edk2_compatible_v1;
 
-static int verify(char **currentVars, int currCount, const char **updateVars,
-		  int updateCount, const char *path, int writeFlag);
+static int verify(char **currentVars, int currCount, const char **updateVars, int updateCount,
+		  const char *path, int writeFlag);
 static int validateVarsArg(const char *vars[], int size);
 static int getCurrentVars(char **newCurr, int *size, const char *path);
 static char *opalErrToString(int rc);
 static int parse_opt(int key, char *arg, struct argp_state *state);
-static int validateBanks(struct list_head *update_bank,
-			 struct list_head *variable_bank);
-static int setupBanks(struct list_head *variable_bank,
-		      struct list_head *update_bank, char *currentVars[],
-		      int currCount, const char *updateVars[], int updateCount,
+static int validateBanks(struct list_head *update_bank, struct list_head *variable_bank);
+static int setupBanks(struct list_head *variable_bank, struct list_head *update_bank,
+		      char *currentVars[], int currCount, const char *updateVars[], int updateCount,
 		      const char *path);
-static void printBanks(struct list_head *variable_bank,
-		       struct list_head *update_bank);
+static void printBanks(struct list_head *variable_bank, struct list_head *update_bank);
 static int commitUpdateBank(struct list_head *update_bank, const char *path);
 
 /**
@@ -54,8 +51,7 @@ int performVerificationCommand(int argc, char *argv[])
 	argv[0] = "secvarctl verify";
 
 	struct argp_option options[] = {
-		{ "verbose", 'v', 0, 0,
-		  "print more verbose process information" },
+		{ "verbose", 'v', 0, 0, "print more verbose process information" },
 		{ "path", 'p', "PATH", 0,
 		  "manually set path to current variables, looks for .../<var>/data file in PATH, default is " SECVARPATH
 		  " . Cannot be used with `-c` " },
@@ -66,8 +62,7 @@ int performVerificationCommand(int argc, char *argv[])
 		{ 0, 'u', "{UPDATE LIST}", OPTION_HIDDEN,
 		  "set update variables (see below for format)" },
 		{ "help", '?', 0, 0, "Give this help list", 1 },
-		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0,
-		  "Give a short usage message", -1 },
+		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{ 0 }
 	};
 
@@ -89,14 +84,13 @@ int performVerificationCommand(int argc, char *argv[])
 		" unless variable is TS (in which case it would contain 4 16 byte timestamps)"
 	};
 
-	rc = argp_parse(&argp, argc, argv,
-			ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
+	rc = argp_parse(&argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag) {
 		goto out;
 	}
 
-	rc = verify(args.currentVars, args.currVarCount, args.updateVars,
-		    args.updateVarCount, args.pathToSecVars, args.writeFlag);
+	rc = verify(args.currentVars, args.currVarCount, args.updateVars, args.updateVarCount,
+		    args.pathToSecVars, args.writeFlag);
 
 out:
 	if (args.currentVars)
@@ -140,19 +134,16 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		break;
 	case 'u':
 		if (args->updateVars) {
-			prlog(PR_ERR,
-			      "ERROR: Update variables defined twice, see usage...\n");
+			prlog(PR_ERR, "ERROR: Update variables defined twice, see usage...\n");
 			argp_usage(state);
 			rc = ARG_PARSE_FAIL;
 			break;
 		}
 		current = state->next - 1;
-		while (state->next != state->argc &&
-		       state->argv[state->next][0] != '-')
+		while (state->next != state->argc && state->argv[state->next][0] != '-')
 			state->next++;
 		args->updateVarCount = (state->next - current);
-		args->updateVars =
-			malloc(sizeof(char *) * args->updateVarCount);
+		args->updateVars = malloc(sizeof(char *) * args->updateVarCount);
 		if (!args->updateVars) {
 			prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 			rc = ALLOC_FAIL;
@@ -163,15 +154,13 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		break;
 	case 'c':
 		if (args->currentVars) {
-			prlog(PR_ERR,
-			      "ERROR: Current variables defined twice, see usage...\n");
+			prlog(PR_ERR, "ERROR: Current variables defined twice, see usage...\n");
 			argp_usage(state);
 			rc = ARG_PARSE_FAIL;
 			break;
 		}
 		current = state->next - 1;
-		while (state->next != state->argc &&
-		       state->argv[state->next][0] != '-')
+		while (state->next != state->argc && state->argv[state->next][0] != '-')
 			state->next++;
 		args->currVarCount = (state->next - current);
 		args->currentVars = malloc(sizeof(char *) * args->currVarCount);
@@ -192,8 +181,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 			      "ERROR: No update variables/files given, use -u <varName_1> <authFileForVar_1>...\n\t\t"
 			      "Where <varName> is one of {'PK','KEK','db','dbx'} and <authFileForVar> is "
 			      "a properly generated authenticated variable file\n");
-		else if (validateVarsArg(args->updateVars,
-					 args->updateVarCount))
+		else if (validateVarsArg(args->updateVars, args->updateVarCount))
 			prlog(PR_ERR,
 			      "ERROR: Update vars list not in right format: "
 			      "-u <varName_1> <authFileForVar_1> <varName_2> <authFileForVar_2> ...\n\t\t"
@@ -203,9 +191,8 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 			if (args->writeFlag)
 				prlog(PR_ERR,
 				      "ERROR: Cannot update files if current variable files are given. remove -w\n");
-			else if (validateVarsArg(
-					 (const char **)args->currentVars,
-					 args->currVarCount))
+			else if (validateVarsArg((const char **)args->currentVars,
+						 args->currVarCount))
 				prlog(PR_ERR,
 				      "ERROR: Current vars list not in right format: "
 				      "<varName_1> <eslFileForVar_1> <varName_2> <eslFileForVar_2> ...\n\t\t"
@@ -236,8 +223,8 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
  *@param writeFlag 0 if -w no given, 1 if given
  *@return SUCCESS or error value
  */
-static int verify(char *currentVars[], int currCount, const char *updateVars[],
-		  int updateCount, const char *path, int writeFlag)
+static int verify(char *currentVars[], int currCount, const char *updateVars[], int updateCount,
+		  const char *path, int writeFlag)
 {
 	int rc;
 	struct list_head update_bank, variable_bank, update_bank_copy;
@@ -248,8 +235,8 @@ static int verify(char *currentVars[], int currCount, const char *updateVars[],
 	if (!path) {
 		path = SECVARPATH;
 	}
-	rc = setupBanks(&variable_bank, &update_bank, currentVars, currCount,
-			updateVars, updateCount, path);
+	rc = setupBanks(&variable_bank, &update_bank, currentVars, currCount, updateVars,
+			updateCount, path);
 	if (rc) {
 		prlog(PR_ERR, "ERROR:Could not initialize banks\n");
 		goto out;
@@ -262,8 +249,7 @@ static int verify(char *currentVars[], int currCount, const char *updateVars[],
 	// run preprocess
 	rc = edk2_compatible_v1.pre_process(&variable_bank, &update_bank);
 	if (rc) {
-		prlog(PR_ERR,
-		      "ERROR: Failed in preprocessing OPAL ERR = %d = %s\n", rc,
+		prlog(PR_ERR, "ERROR: Failed in preprocessing OPAL ERR = %d = %s\n", rc,
 		      opalErrToString(rc));
 		goto out;
 	}
@@ -277,8 +263,7 @@ static int verify(char *currentVars[], int currCount, const char *updateVars[],
 	// run process
 	rc = edk2_compatible_v1.process(&variable_bank, &update_bank);
 	if (rc) {
-		prlog(PR_ERR,
-		      "ERROR: Failed in processing OPAL ERR = %d = %s\n", rc,
+		prlog(PR_ERR, "ERROR: Failed in processing OPAL ERR = %d = %s\n", rc,
 		      opalErrToString(rc));
 		goto out;
 	}
@@ -290,8 +275,7 @@ static int verify(char *currentVars[], int currCount, const char *updateVars[],
 	if (writeFlag) {
 		rc = commitUpdateBank(&update_bank_copy, path);
 		if (rc) {
-			prlog(PR_ERR,
-			      "ERROR: Failed in submitting update #%d\n", rc);
+			prlog(PR_ERR, "ERROR: Failed in submitting update #%d\n", rc);
 			goto out;
 		}
 	}
@@ -314,9 +298,8 @@ out:
  *@param path holds path to current vars
  *@return SUCCESS or error value
  */
-static int setupBanks(struct list_head *variable_bank,
-		      struct list_head *update_bank, char *currentVars[],
-		      int currCount, const char *updateVars[], int updateCount,
+static int setupBanks(struct list_head *variable_bank, struct list_head *update_bank,
+		      char *currentVars[], int currCount, const char *updateVars[], int updateCount,
 		      const char *path)
 {
 	int defaultVarsFlag = 0;
@@ -328,17 +311,14 @@ static int setupBanks(struct list_head *variable_bank,
 	if (!currentVars) {
 		defaultVarsFlag = 1;
 		// max length of this array is #OfVars *2 b/c max contents= {Pk, path/pk/data, KEK, path/kek/data,etc}
-		currentVars =
-			calloc(1, sizeof(char *) * ARRAY_SIZE(variables) * 2);
+		currentVars = calloc(1, sizeof(char *) * ARRAY_SIZE(variables) * 2);
 		if (!currentVars) {
 			prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 			return ALLOC_FAIL;
 		}
 		// unlikely fail, if alloc fails
 		if (getCurrentVars(currentVars, &currCount, path)) {
-			prlog(PR_ERR,
-			      "Could not get current variables from path %s\n",
-			      path);
+			prlog(PR_ERR, "Could not get current variables from path %s\n", path);
 			return INVALID_FILE;
 		}
 	}
@@ -348,38 +328,31 @@ static int setupBanks(struct list_head *variable_bank,
 	for (int i = 0; i < updateCount; i += 2) {
 		c = getDataFromFile((char *)updateVars[i + 1], &len);
 		if (c) {
-			list_add_tail(update_bank,
-				      &new_secvar(updateVars[i],
-						  strlen(updateVars[i]) + 1, c,
-						  len, 0)
-					       ->link);
+			list_add_tail(update_bank, &new_secvar(updateVars[i],
+							       strlen(updateVars[i]) + 1, c, len, 0)
+							    ->link);
 			free(c);
 		} else
-			prlog(PR_INFO,
-			      "Failed to open %s, not adding it to list\n",
+			prlog(PR_INFO, "Failed to open %s, not adding it to list\n",
 			      updateVars[i + 1]);
 	}
 	// fill variable bank with current vars
 	for (int i = 0; i < currCount; i += 2) {
 		if (defaultVarsFlag) {
 			// if getting secvar successful add tmp to list
-			if (!getSecVar(&tmp, currentVars[i],
-				       currentVars[i + 1]))
+			if (!getSecVar(&tmp, currentVars[i], currentVars[i + 1]))
 				list_add_tail(variable_bank, &tmp->link);
 
 		} else {
 			c = getDataFromFile((char *)currentVars[i + 1], &len);
 			if (c) {
-				list_add_tail(
-					variable_bank,
-					&new_secvar(currentVars[i],
-						    strlen(currentVars[i]) + 1,
-						    c, len, 0)
-						 ->link);
+				list_add_tail(variable_bank,
+					      &new_secvar(currentVars[i],
+							  strlen(currentVars[i]) + 1, c, len, 0)
+						       ->link);
 				free(c);
 			} else
-				prlog(PR_INFO,
-				      "Failed to open %s, not adding it to list\n",
+				prlog(PR_INFO, "Failed to open %s, not adding it to list\n",
 				      currentVars[i + 1]);
 		}
 	}
@@ -400,8 +373,7 @@ static int setupBanks(struct list_head *variable_bank,
  *@param update_bank list of secvar's of update variables
  *@return SUCCESS or error value if any files fail
  */
-static int validateBanks(struct list_head *update_bank,
-			 struct list_head *variable_bank)
+static int validateBanks(struct list_head *update_bank, struct list_head *variable_bank)
 {
 	int rc = SUCCESS;
 	struct secvar *var = NULL;
@@ -417,11 +389,9 @@ static int validateBanks(struct list_head *update_bank,
 			      var->key);
 			return rc;
 		}
-		rc = validateAuth((unsigned char *)var->data, var->data_size,
-				  var->key);
+		rc = validateAuth((unsigned char *)var->data, var->data_size, var->key);
 		if (rc) {
-			prlog(PR_ERR,
-			      "ERROR: failed to validate Auth file for %s, returned %d\n",
+			prlog(PR_ERR, "ERROR: failed to validate Auth file for %s, returned %d\n",
 			      var->key, rc);
 			return rc;
 		}
@@ -430,14 +400,12 @@ static int validateBanks(struct list_head *update_bank,
 	// if no PK then were in setup mode so skip vallidation of current keys
 	if (find_secvar("PK", 3, variable_bank)) {
 		list_for_each (variable_bank, var, link) {
-			prlog(PR_INFO, "----VALIDATING CURRENT VAR: %s----\n",
-			      var->key);
+			prlog(PR_INFO, "----VALIDATING CURRENT VAR: %s----\n", var->key);
 			if (strcmp(var->key, "TS") == 0)
-				rc = validateTS((unsigned char *)var->data,
-						var->data_size);
+				rc = validateTS((unsigned char *)var->data, var->data_size);
 			else
-				rc = validateESL((unsigned char *)var->data,
-						 var->data_size, var->key);
+				rc = validateESL((unsigned char *)var->data, var->data_size,
+						 var->key);
 			if (rc) {
 				prlog(PR_ERR,
 				      "ERROR: failed to validate data file for %s,returned %d\n",
@@ -516,8 +484,7 @@ static int getCurrentVars(char *newCurr[], int *size, const char *path)
 	char *ext = "/data";
 	char *fullPath = NULL;
 	for (i = 0; i < ARRAY_SIZE(variables); i++) {
-		fullPath = malloc(strlen(path) + strlen(variables[i]) +
-				  strlen(ext) + 1);
+		fullPath = malloc(strlen(path) + strlen(variables[i]) + strlen(ext) + 1);
 		if (!fullPath) {
 			prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 			return ALLOC_FAIL;
@@ -531,17 +498,14 @@ static int getCurrentVars(char *newCurr[], int *size, const char *path)
 		if (!isFile(fullPath)) {
 			newCurr[lenCtr] = malloc(strlen(variables[i]) + 1);
 			if (!newCurr[lenCtr]) {
-				prlog(PR_ERR,
-				      "ERROR: failed to allocate memory\n");
+				prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 				free(fullPath);
 				return ALLOC_FAIL;
 			}
-			strncpy(newCurr[lenCtr++], variables[i],
-				strlen(variables[i]) + 1);
+			strncpy(newCurr[lenCtr++], variables[i], strlen(variables[i]) + 1);
 			newCurr[lenCtr] = malloc(strlen(fullPath) + 1);
 			if (!newCurr[lenCtr]) {
-				prlog(PR_ERR,
-				      "ERROR: failed to allocate memory\n");
+				prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 				free(fullPath);
 				return ALLOC_FAIL;
 			}
@@ -562,20 +526,17 @@ static int getCurrentVars(char *newCurr[], int *size, const char *path)
  *@param variable_bank list of secvar's of current variables
  *@param update_bank list of secvar's of update variables
  */
-static void printBanks(struct list_head *variable_bank,
-		       struct list_head *update_bank)
+static void printBanks(struct list_head *variable_bank, struct list_head *update_bank)
 {
 	struct secvar *var = NULL;
 	printf("----CONTENTS OF UPDATE BANK----\n");
 	list_for_each (update_bank, var, link) {
-		printf("SecVar for %s contains %zd bytes of data\n", var->key,
-		       var->data_size);
+		printf("SecVar for %s contains %zd bytes of data\n", var->key, var->data_size);
 	}
 
 	printf("----CONTENTS OF VARIABLE BANK----\n");
 	list_for_each (variable_bank, var, link) {
-		printf("SecVar for %s contains %zd bytes of data\n", var->key,
-		       var->data_size);
+		printf("SecVar for %s contains %zd bytes of data\n", var->key, var->data_size);
 	}
 }
 
@@ -590,11 +551,9 @@ static int commitUpdateBank(struct list_head *update_bank, const char *path)
 	int rc = INVALID_FILE;
 	struct secvar *var = NULL;
 	list_for_each (update_bank, var, link) {
-		prlog(PR_INFO,
-		      "Writing new %s with %zd bytes of data to %s%s/update\n",
-		      var->key, var->data_size, path, var->key);
-		rc = updateVar(path, var->key, (unsigned char *)var->data,
-			       var->data_size);
+		prlog(PR_INFO, "Writing new %s with %zd bytes of data to %s%s/update\n", var->key,
+		      var->data_size, path, var->key);
+		rc = updateVar(path, var->key, (unsigned char *)var->data, var->data_size);
 		if (rc) {
 			prlog(PR_ERR, "ERROR: issue writing to file #%d\n",
 			      rc); // consider continuing

--- a/backends/edk2-compat/edk2-svc-write.c
+++ b/backends/edk2-compat/edk2-svc-write.c
@@ -10,8 +10,7 @@
 #include "secvarctl.h"
 #include "backends/edk2-compat/include/edk2-svc.h" // import last!!
 
-static int updateSecVar(const char *var, const char *authFile, const char *path,
-			int force);
+static int updateSecVar(const char *var, const char *authFile, const char *path, int force);
 
 struct Arguments {
 	int helpFlag, inpValid;
@@ -29,24 +28,19 @@ static int parse_opt(int key, char *arg, struct argp_state *state);
 int performWriteCommand(int argc, char *argv[])
 {
 	int rc;
-	struct Arguments args = { .helpFlag = 0,
-				  .inpValid = 0,
-				  .pathToSecVars = NULL,
-				  .inFile = NULL,
-				  .varName = NULL };
+	struct Arguments args = {
+		.helpFlag = 0, .inpValid = 0, .pathToSecVars = NULL, .inFile = NULL, .varName = NULL
+	};
 	// combine command and subcommand for usage/help messages
 	argv[0] = "secvarctl write";
 
 	struct argp_option options[] = {
-		{ "verbose", 'v', 0, 0,
-		  "print more verbose process information" },
-		{ "force", 'f', 0, 0,
-		  "force update, skips validation of file" },
+		{ "verbose", 'v', 0, 0, "print more verbose process information" },
+		{ "force", 'f', 0, 0, "force update, skips validation of file" },
 		{ "path", 'p', "PATH", 0,
 		  "looks for .../<var>/update file in PATH, default is " SECVARPATH },
 		{ "help", '?', 0, 0, "Give this help list", 1 },
-		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0,
-		  "Give a short usage message", -1 },
+		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 		{ 0 }
 	};
 
@@ -59,13 +53,11 @@ int performWriteCommand(int argc, char *argv[])
 		"<AUTH_FILE> must be a properly generated authenticated variable file"
 	};
 
-	rc = argp_parse(&argp, argc, argv,
-			ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
+	rc = argp_parse(&argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
 	if (rc || args.helpFlag)
 		goto out;
 
-	rc = updateSecVar(args.varName, args.inFile, args.pathToSecVars,
-			  args.inpValid);
+	rc = updateSecVar(args.varName, args.inFile, args.pathToSecVars, args.inpValid);
 
 out:
 	if (!args.helpFlag)
@@ -114,14 +106,11 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		if (args->helpFlag)
 			break;
 		if (!args->varName)
-			prlog(PR_ERR,
-			      "ERROR: missing variable, see usage...\n");
+			prlog(PR_ERR, "ERROR: missing variable, see usage...\n");
 		else if (!args->inFile)
-			prlog(PR_ERR,
-			      "ERROR: missing input file, see usage...\n");
+			prlog(PR_ERR, "ERROR: missing input file, see usage...\n");
 		else if (isVariable(args->varName))
-			prlog(PR_ERR,
-			      "ERROR: Unrecognized variable name %s, see usage...\n",
+			prlog(PR_ERR, "ERROR: Unrecognized variable name %s, see usage...\n",
 			      args->varName);
 		else if (strcmp(args->varName, "TS") == 0)
 			prlog(PR_ERR,
@@ -162,8 +151,7 @@ int isVariable(const char *var)
  *@param force 1 for no validation of auth, 0 for validate
  *@return error if variable given is unknown, or issue validating or writing
  */
-static int updateSecVar(const char *varName, const char *authFile,
-			const char *path, int force)
+static int updateSecVar(const char *varName, const char *authFile, const char *path, int force)
 {
 	int rc;
 	unsigned char *buff = NULL;
@@ -188,8 +176,7 @@ static int updateSecVar(const char *varName, const char *authFile,
 	rc = updateVar(path, varName, buff, size);
 
 	if (rc)
-		prlog(PR_ERR, "ERROR: issue writing to file: %s\n",
-		      strerror(errno));
+		prlog(PR_ERR, "ERROR: issue writing to file: %s\n", strerror(errno));
 	free(buff);
 
 	return rc;
@@ -203,8 +190,7 @@ static int updateSecVar(const char *varName, const char *authFile,
  *@param size , size of buff
  *@return whatever returned by writeData, SUCCESS or errno
  */
-int updateVar(const char *path, const char *var, const unsigned char *buff,
-	      size_t size)
+int updateVar(const char *path, const char *var, const unsigned char *buff, size_t size)
 {
 	int commandLength, rc;
 	char *fullPathWithCommand = NULL;

--- a/backends/edk2-compat/edk2-svc-write.c
+++ b/backends/edk2-compat/edk2-svc-write.c
@@ -8,7 +8,7 @@
 #include <stdlib.h> // for exit
 #include <argp.h>
 #include "secvarctl.h"
-#include "backends/edk2-compat/include/edk2-svc.h" // import last!!
+#include "backends/edk2-compat/include/edk2-svc.h"
 
 static int updateSecVar(const char *var, const char *authFile, const char *path, int force);
 

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -20,10 +20,10 @@
 #define SECVARPATH "/sys/firmware/secvar/vars/"
 #endif
 
-#define variables                                                              \
-	(char *[])                                                             \
-	{                                                                      \
-		"PK", "KEK", "db", "dbx", "TS"                                 \
+#define variables                                                                                  \
+	(char *[])                                                                                 \
+	{                                                                                          \
+		"PK", "KEK", "db", "dbx", "TS"                                                     \
 	}
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 #define uuid_equals(a, b) (!memcmp(a, b, UUID_SIZE))
@@ -75,14 +75,12 @@ int parseX509(crypto_x509 **x509, const unsigned char *certBuf, size_t buflen);
 const char *getSigType(const uuid_t);
 
 int getSecVar(struct secvar **var, const char *name, const char *fullPath);
-int updateVar(const char *path, const char *var, const unsigned char *buff,
-	      size_t size);
+int updateVar(const char *path, const char *var, const unsigned char *buff, size_t size);
 int isVariable(const char *var);
 
 int validateAuth(const unsigned char *authBuf, size_t buflen, const char *key);
 int validateESL(const unsigned char *eslBuf, size_t buflen, const char *key);
-int validateCert(const unsigned char *authBuf, size_t buflen,
-		 const char *varName);
+int validateCert(const unsigned char *authBuf, size_t buflen, const char *varName);
 int validatePKCS7(const unsigned char *cert_data, size_t len);
 int validateTS(const unsigned char *data, size_t size);
 int validateTime(struct efi_time *time);

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -9,7 +9,7 @@
 #include "prlog.h"
 #include "generic.h"
 #include "libstb/secvar/crypto/crypto.h"
-#include "external/skiboot/libstb/secvar/backend/edk2.h" // include last or else problems from pragma pack(1)
+#include "external/skiboot/libstb/secvar/backend/edk2.h"
 
 // all argp options must have a single character option
 // so we set --usage to have a single character option that is out of range

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -69,7 +69,6 @@ void printESLInfo(EFI_SIGNATURE_LIST *sigList);
 void printTimestamp(struct efi_time t);
 void printGuidSig(const void *sig);
 
-ssize_t get_esl_cert(const char *c, EFI_SIGNATURE_LIST *list, char **cert);
 size_t get_pkcs7_len(const struct efi_variable_authentication_2 *auth);
 int parseX509(crypto_x509 **x509, const unsigned char *certBuf, size_t buflen);
 const char *getSigType(const uuid_t);

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -69,7 +69,6 @@ void printESLInfo(EFI_SIGNATURE_LIST *sigList);
 void printTimestamp(struct efi_time t);
 void printGuidSig(const void *sig);
 
-size_t get_pkcs7_len(const struct efi_variable_authentication_2 *auth);
 int parseX509(crypto_x509 **x509, const unsigned char *certBuf, size_t buflen);
 const char *getSigType(const uuid_t);
 

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -10,6 +10,7 @@
 #include "generic.h"
 #include "libstb/secvar/crypto/crypto.h"
 #include "external/skiboot/libstb/secvar/backend/edk2.h"
+#include "external/skiboot/libstb/secvar/backend/edk2-compat-process.h"
 
 // all argp options must have a single character option
 // so we set --usage to have a single character option that is out of range
@@ -68,7 +69,6 @@ void printESLInfo(EFI_SIGNATURE_LIST *sigList);
 void printTimestamp(struct efi_time t);
 void printGuidSig(const void *sig);
 
-EFI_SIGNATURE_LIST *get_esl_signature_list(const char *buf, size_t buflen);
 ssize_t get_esl_cert(const char *c, EFI_SIGNATURE_LIST *list, char **cert);
 size_t get_pkcs7_len(const struct efi_variable_authentication_2 *auth);
 int parseX509(crypto_x509 **x509, const unsigned char *certBuf, size_t buflen);

--- a/external/linux/.clang-format
+++ b/external/linux/.clang-format
@@ -52,7 +52,7 @@ BreakConstructorInitializersBeforeComma: false
 #BreakConstructorInitializers: BeforeComma # Unknown to clang-format-4.0
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: false
-ColumnLimit: 80
+ColumnLimit: 100
 CommentPragmas: '^ IWYU pragma:'
 #CompactNamespaces: false # Unknown to clang-format-4.0
 ConstructorInitializerAllOnOneLineOrOnePerLine: false

--- a/external/skiboot/include/compiler.h
+++ b/external/skiboot/include/compiler.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+/* Copyright 2013-2019 IBM Corp. */
+
+#ifndef __COMPILER_H
+#define __COMPILER_H
+
+#ifndef __ASSEMBLY__
+
+#include <stddef.h>
+
+/* Macros for various compiler bits and pieces */
+#define __packed		__attribute__((packed))
+#define __align(x)		__attribute__((__aligned__(x)))
+#define __unused		__attribute__((unused))
+#define __used			__attribute__((used))
+#define __section(x)		__attribute__((__section__(x)))
+#define __noreturn		__attribute__((noreturn))
+/* not __const as this has a different meaning (const) */
+#define __attrconst		__attribute__((const))
+#define __warn_unused_result	__attribute__((warn_unused_result))
+#define __noinline		__attribute__((noinline))
+
+#if 0 /* Provided by gcc stddef.h */
+#define offsetof(type,m)	__builtin_offsetof(type,m)
+#endif
+
+#define __nomcount		__attribute__((no_instrument_function))
+
+/* Compiler barrier */
+static inline void barrier(void)
+{
+	asm volatile("" : : : "memory");
+}
+
+#endif /* __ASSEMBLY__ */
+
+/* Stringification macro */
+#define __tostr(x)	#x
+#define tostr(x)	__tostr(x)
+
+#endif /* __COMPILER_H */

--- a/external/skiboot/libstb/secvar/backend/edk2-compat-process.c
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat-process.c
@@ -95,12 +95,14 @@ static void get_key_authority(const char *ret[3], const char *key)
 	ret[i] = NULL;
 }
 
-static EFI_SIGNATURE_LIST* get_esl_signature_list(const char *buf, size_t buflen)
+EFI_SIGNATURE_LIST* get_esl_signature_list(const char *buf, size_t buflen)
 {
 	EFI_SIGNATURE_LIST *list = NULL;
 
-	if (buflen < sizeof(EFI_SIGNATURE_LIST) || !buf)
+	if (buflen < sizeof(EFI_SIGNATURE_LIST) || !buf) {
+		prlog(PR_ERR, "ERROR: SigList does not have enough data to be valid\n");
 		return NULL;
+	}
 
 	list = (EFI_SIGNATURE_LIST *)buf;
 
@@ -125,7 +127,7 @@ static int32_t get_esl_signature_list_size(const char *buf, const size_t buflen)
  * Copies the certificate from the ESL into cert buffer and returns the size
  * of the certificate
  */
-static int get_esl_cert(const char *buf, const size_t buflen, char **cert)
+int get_esl_cert(const char *buf, const size_t buflen, char **cert)
 {
 	size_t sig_data_offset;
 	size_t size;
@@ -166,7 +168,7 @@ static int get_esl_cert(const char *buf, const size_t buflen, char **cert)
  * Extracts size of the PKCS7 signed data embedded in the
  * struct Authentication 2 Descriptor Header.
  */
-static size_t get_pkcs7_len(const struct efi_variable_authentication_2 *auth)
+size_t get_pkcs7_len(const struct efi_variable_authentication_2 *auth)
 {
 	uint32_t dw_length;
 	size_t size;

--- a/external/skiboot/libstb/secvar/backend/edk2-compat-process.h
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat-process.h
@@ -77,4 +77,32 @@ int process_update(const struct secvar *update, char **newesl,
 		   int *neweslsize, struct efi_time *timestamp,
 		   struct list_head *bank, char *last_timestamp);
 
+
+/* Functions used by external secvarctl */
+
+/**
+ * Parse a buffer into a EFI_SIGNATURE_LIST structure
+ * @param buf pointer to a buffer containing an ESL
+ * @param buflen length of buffer
+ * @return NULL if buflen is smaller than size of sig list struct or if buf is NULL
+ * @return EFI_SIGNATURE_LIST struct
+ */
+EFI_SIGNATURE_LIST* get_esl_signature_list(const char *buf, size_t buflen);
+
+/**
+ * Copies the certificate from the ESL into cert buffer and returns the size
+ * of the certificate.
+ * @param c Buffer containing an EFI Signature List
+ * @param size size of buffer c
+ * @param cert pointer to destination. Memory will be allocated for the certificate
+ * @return size of memory allocated to cert or negative number if allocation fails
+ */
+int get_esl_cert(const char *buf, const size_t buflen, char **cert);
+
+/*
+ * Extracts size of the PKCS7 signed data embedded in the
+ * struct Authentication 2 Descriptor Header.
+ */
+size_t get_pkcs7_len(const struct efi_variable_authentication_2 *auth);
+
 #endif

--- a/external/skiboot/libstb/secvar/backend/edk2-compat-process.h
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat-process.h
@@ -27,8 +27,7 @@
 #include "external/skiboot/include/opal-api.h"
 //#include "external/extraMbedtls/include/pkcs7.h"
 #include "external/skiboot/libstb/secvar/backend/edk2.h"
-
-#define __unused		__attribute__((unused)) //ADDED BY NICK CHILD
+#include <compiler.h>
 
 //ADDED BY NICK CHILD
 #define PR_ERR		3

--- a/external/skiboot/libstb/secvar/backend/edk2.h
+++ b/external/skiboot/libstb/secvar/backend/edk2.h
@@ -41,7 +41,10 @@
 
 #ifndef __EDK2_H__
 #define __EDK2_H__
-#include <ccan/short_types/short_types.h> //added by Nick Child, dja
+
+#include <compiler.h>
+#include <ccan/short_types/short_types.h>
+
 #define UUID_SIZE 16
 
 typedef struct {
@@ -49,14 +52,13 @@ typedef struct {
 } uuid_t;
 
 #define EFI_GLOBAL_VARIABLE_GUID (uuid_t){{0x61, 0xDF, 0xe4, 0x8b, 0xca, 0x93, 0xd2, 0x11, 0xaa, \
-       0x0d, 0x00, 0xe0, 0x98, 0x03, 0x2b, 0x8c}}
+			 0x0d, 0x00, 0xe0, 0x98, 0x03, 0x2b, 0x8c}}
 
 #define EFI_IMAGE_SECURITY_DATABASE_GUID (uuid_t){{0xcb, 0xb2, 0x19, 0xd7, 0x3a, 0x3d, 0x96, 0x45, \
-             0xa3, 0xbc, 0xda, 0xd0, 0x0e, 0x67, 0x65, 0x6f}}
+					   0xa3, 0xbc, 0xda, 0xd0, 0x0e, 0x67, 0x65, 0x6f}}
 
-#define SECVAR_ATTRIBUTES 39
+#define SECVAR_ATTRIBUTES	39
 
-#define EFI_CERT_RSA2048_GUID (uuid_t) {{0xe8,0x66,0x57, 0x3c, 0x9c, 0x26,0x34,  0x4e,  0xaa, 0x14, 0xed, 0x77, 0x6e, 0x85, 0xb3, 0xb6}} //ADDED BY NICK CHILD
 ///
 /// This identifies a signature based on an X.509 certificate. If the signature is an X.509
 /// certificate then verification of the signature of an image should validate the public
@@ -81,25 +83,27 @@ static const uuid_t EFI_CERT_SHA384_GUID = {{ 0x07, 0x53, 0x3e, 0xff, 0xd0, 0x9f
 
 static const uuid_t EFI_CERT_SHA512_GUID = {{ 0xae, 0x0f, 0x3e, 0x09, 0xc4, 0xa6, 0x50, 0x4f, 0x9f, 0x1b, 0xd4, 0x1e, 0x2b, 0x89, 0xc1, 0x9a }};
 
-#define EFI_VARIABLE_NON_VOLATILE       0x00000001
-#define EFI_VARIABLE_BOOTSERVICE_ACCESS       0x00000002
-#define EFI_VARIABLE_RUNTIME_ACCESS       0x00000004
+static const uuid_t EFI_CERT_RSA2048_GUID = {{ 0xe8, 0x66, 0x57, 0x3c, 0x9c, 0x26, 0x34, 0x4e, 0xaa, 0x14, 0xed, 0x77, 0x6e, 0x85, 0xb3, 0xb6 }};
+
+#define EFI_VARIABLE_NON_VOLATILE				0x00000001
+#define EFI_VARIABLE_BOOTSERVICE_ACCESS				0x00000002
+#define EFI_VARIABLE_RUNTIME_ACCESS				0x00000004
 
 /*
  * Attributes of Authenticated Variable
  */
-#define EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS  0x00000020
-#define EFI_VARIABLE_APPEND_WRITE       0x00000040
+#define EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS	0x00000020
+#define EFI_VARIABLE_APPEND_WRITE				0x00000040
 /*
  * NOTE: EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS is deprecated and should be
  * considered reserved.
  */
-#define EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS     0x00000010
+#define EFI_VARIABLE_AUTHENTICATED_WRITE_ACCESS			0x00000010
 
 /*
  * win_certificate.w_certificate_type
  */
-#define WIN_CERT_TYPE_PKCS_SIGNED_DATA  0x0002
+#define WIN_CERT_TYPE_PKCS_SIGNED_DATA	0x0002
 
 #define SECURE_BOOT_MODE_ENABLE           1
 #define SECURE_BOOT_MODE_DISABLE          0
@@ -121,17 +125,17 @@ static const uuid_t EFI_CERT_SHA512_GUID = {{ 0xae, 0x0f, 0x3e, 0x09, 0xc4, 0xa6
  *   TimeZone:   -1440 to 1440 or 2047
  */
 struct efi_time {
-  u16 year;
-  u8 month;
-  u8 day;
-  u8 hour;
-  u8 minute;
-  u8 second;
-  u8 pad1;
-  u32 nanosecond;
-  s16 timezone;
-  u8 daylight;
-  u8 pad2;
+	u16 year;
+	u8 month;
+	u8 day;
+	u8 hour;
+	u8 minute;
+	u8 second;
+	u8 pad1;
+	u32 nanosecond;
+	s16 timezone;
+	u8 daylight;
+	u8 pad2;
 };
 //***********************************************************************
 // Signature Database
@@ -139,9 +143,8 @@ struct efi_time {
 ///
 /// The format of a signature database.
 ///
-#pragma pack(1)
 
-typedef struct {
+typedef struct __packed {
   ///
   /// An identifier which identifies the agent which added the signature to the list.
   ///
@@ -152,7 +155,7 @@ typedef struct {
   unsigned char SignatureData[0];
 } EFI_SIGNATURE_DATA;
 
-typedef struct {
+typedef struct __packed {
   ///
   /// Type of the signature. GUID signature types are defined in below.
   ///
@@ -160,15 +163,15 @@ typedef struct {
   ///
   /// Total size of the signature list, including this header.
   ///
-  uint32_t  SignatureListSize;
+  uint32_t	SignatureListSize;
   ///
   /// Size of the signature header which precedes the array of signatures.
   ///
-  uint32_t  SignatureHeaderSize;
+  uint32_t	SignatureHeaderSize;
   ///
   /// Size of each signature.
   ///
-  uint32_t  SignatureSize;
+  uint32_t	SignatureSize;
   ///
   /// Header before the array of signatures. The format of this header is specified
   /// by the SignatureType.
@@ -184,50 +187,51 @@ typedef struct {
  * The win_certificate structure is part of the PE/COFF specification.
  */
 struct win_certificate {
-  /*
-   * The length of the entire certificate, including the length of the
-   * header, in bytes.
-   */
-  u32  dw_length;
-  /*
-   * The revision level of the WIN_CERTIFICATE structure. The current
-   * revision level is 0x0200.
-   */
-  u16  w_revision;
-  /*
-   * The certificate type. See WIN_CERT_TYPE_xxx for the UEFI certificate
-   * types. The UEFI specification reserves the range of certificate type
-   * values from 0x0EF0 to 0x0EFF.
-   */
-  u16  w_certificate_type;
-  /*
-   * The following is the actual certificate. The format of
-   * the certificate depends on wCertificateType.
-   */
-  /// UINT8 bCertificate[ANYSIZE_ARRAY];
-};
+	/*
+	 * The length of the entire certificate, including the length of the
+	 * header, in bytes.
+	 */
+	u32  dw_length;
+	/*
+	 * The revision level of the WIN_CERTIFICATE structure. The current
+	 * revision level is 0x0200.
+	 */
+	u16  w_revision;
+	/*
+	 * The certificate type. See WIN_CERT_TYPE_xxx for the UEFI certificate
+	 * types. The UEFI specification reserves the range of certificate type
+	 * values from 0x0EF0 to 0x0EFF.
+	 */
+	u16  w_certificate_type;
+	/*
+	 * The following is the actual certificate. The format of
+	 * the certificate depends on wCertificateType.
+	 */
+	/// UINT8 bCertificate[ANYSIZE_ARRAY];
+} __packed;
 
 /*
  * Certificate which encapsulates a GUID-specific digital signature
  */
 struct win_certificate_uefi_guid {
-  /*
-   * This is the standard win_certificate header, where w_certificate_type
-   * is set to WIN_CERT_TYPE_EFI_GUID.
-   */
-  struct win_certificate hdr;
-  /*
-   * This is the unique id which determines the format of the cert_data.
-   */
-  uuid_t cert_type;
-  /*
-   * The following is the certificate data. The format of the data is
-   * determined by the @cert_type. If @cert_type is
-   * EFI_CERT_TYPE_RSA2048_SHA256_GUID, the @cert_data will be
-   * EFI_CERT_BLOCK_RSA_2048_SHA256 structure.
-   */
-  u8 cert_data[];
-};
+	/*
+	 * This is the standard win_certificate header, where w_certificate_type
+	 * is set to WIN_CERT_TYPE_EFI_GUID.
+	 */
+	struct win_certificate hdr;
+	/*
+	 * This is the unique id which determines the format of the cert_data.
+	 */
+	uuid_t cert_type;
+	/*
+	 * The following is the certificate data. The format of the data is
+	 * determined by the @cert_type. If @cert_type is
+	 * EFI_CERT_TYPE_RSA2048_SHA256_GUID, the @cert_data will be
+	 * EFI_CERT_BLOCK_RSA_2048_SHA256 structure.
+	 */
+	u8 cert_data[];
+} __packed;
+
 /*
  * When the attribute EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS is set,
  * then the Data buffer shall begin with an instance of a complete (and
@@ -238,15 +242,15 @@ struct win_certificate_uefi_guid {
  * calls to GetVariable().
  */
 struct efi_variable_authentication_2 {
-  /*
-   * For the TimeStamp value, components Pad1, Nanosecond, TimeZone, Daylight and
-   * Pad2 shall be set to 0. This means that the time shall always be expressed in GMT.
-   */
-  struct efi_time timestamp;
-  /*
-   * Only a CertType of  EFI_CERT_TYPE_PKCS7_GUID is accepted.
-   */
-  struct win_certificate_uefi_guid auth_info;
-};
+	/*
+	 * For the TimeStamp value, components Pad1, Nanosecond, TimeZone, Daylight and
+	 * Pad2 shall be set to 0. This means that the time shall always be expressed in GMT.
+	 */
+	struct efi_time timestamp;
+	/*
+	 * Only a CertType of  EFI_CERT_TYPE_PKCS7_GUID is accepted.
+	 */
+	struct win_certificate_uefi_guid auth_info;
+} __packed;
 
 #endif

--- a/generic.c
+++ b/generic.c
@@ -73,8 +73,7 @@ char *getDataFromFile(const char *fullPath, size_t *size)
 	ssize_t read_size;
 	fptr = open(fullPath, O_RDONLY);
 	if (fptr < 0) {
-		prlog(PR_WARNING, "----opening %s failed : %s----\n", fullPath,
-		      strerror(errno));
+		prlog(PR_WARNING, "----opening %s failed : %s----\n", fullPath, strerror(errno));
 		return NULL;
 	}
 	if (fstat(fptr, &fileInfo) < 0) {
@@ -83,8 +82,8 @@ char *getDataFromFile(const char *fullPath, size_t *size)
 	if (fileInfo.st_size <= 0) {
 		prlog(PR_WARNING, "WARNING: file %s is empty\n", fullPath);
 	}
-	prlog(PR_NOTICE, "----opening %s is success: reading %ld bytes----\n",
-	      fullPath, fileInfo.st_size);
+	prlog(PR_NOTICE, "----opening %s is success: reading %ld bytes----\n", fullPath,
+	      fileInfo.st_size);
 	c = malloc(fileInfo.st_size);
 	if (!c) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
@@ -92,9 +91,7 @@ char *getDataFromFile(const char *fullPath, size_t *size)
 	}
 	read_size = read(fptr, c, fileInfo.st_size);
 	if (read_size != fileInfo.st_size) {
-		prlog(PR_ERR,
-		      "ERROR: failed to read whole contents of %s in one go\n",
-		      fullPath);
+		prlog(PR_ERR, "ERROR: failed to read whole contents of %s in one go\n", fullPath);
 		free(c);
 		c = NULL;
 		goto out;
@@ -118,8 +115,7 @@ int writeData(const char *file, const char *buff, size_t size)
 {
 	int rc, fptr = open(file, O_WRONLY | O_TRUNC);
 	if (fptr == -1) {
-		prlog(PR_ERR, "ERROR: Opening %s failed: %s\n", file,
-		      strerror(errno));
+		prlog(PR_ERR, "ERROR: Opening %s failed: %s\n", file, strerror(errno));
 		return INVALID_FILE;
 	}
 	rc = write(fptr, buff, size);
@@ -127,13 +123,10 @@ int writeData(const char *file, const char *buff, size_t size)
 		prlog(PR_ERR, "ERROR: Writing data to %s failed\n", file);
 		return FILE_WRITE_FAIL;
 	} else if (rc == 0) {
-		prlog(PR_WARNING,
-		      "End of file reached, not all of file was written to %s\n",
-		      file);
+		prlog(PR_WARNING, "End of file reached, not all of file was written to %s\n", file);
 	} else
-		prlog(PR_NOTICE,
-		      "%d/%zd bytes successfully written from file to %s\n", rc,
-		      size, file);
+		prlog(PR_NOTICE, "%d/%zd bytes successfully written from file to %s\n", rc, size,
+		      file);
 	close(fptr);
 
 	return SUCCESS;
@@ -151,26 +144,20 @@ int createFile(const char *file, const char *buff, size_t size)
 {
 	int rc;
 	// create and set permissions
-	int fptr = open(file, O_WRONLY | O_TRUNC | O_CREAT,
-			S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+	int fptr = open(file, O_WRONLY | O_TRUNC | O_CREAT, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
 	if (fptr == -1) {
-		prlog(PR_ERR, "ERROR: Opening %s failed: %s\n", file,
-		      strerror(errno));
+		prlog(PR_ERR, "ERROR: Opening %s failed: %s\n", file, strerror(errno));
 		return INVALID_FILE;
 	}
 	rc = write(fptr, buff, size);
 	if (rc < 0) {
-		prlog(PR_ERR, "ERROR: Writing data to %s failed: %s\n", file,
-		      strerror(errno));
+		prlog(PR_ERR, "ERROR: Writing data to %s failed: %s\n", file, strerror(errno));
 		return FILE_WRITE_FAIL;
 	} else if (rc == 0) {
-		prlog(PR_WARNING,
-		      "End of file reached, not all of file was written to %s\n",
-		      file);
+		prlog(PR_WARNING, "End of file reached, not all of file was written to %s\n", file);
 	} else
-		prlog(PR_NOTICE,
-		      "%d/%zd bytes successfully written from file to %s\n", rc,
-		      size, file);
+		prlog(PR_NOTICE, "%d/%zd bytes successfully written from file to %s\n", rc, size,
+		      file);
 	close(fptr);
 
 	return SUCCESS;
@@ -191,8 +178,7 @@ int reallocArray(void **arr, size_t new_length, size_t size_each)
 	old_arr = *arr;
 	//check if requested size is too big
 	if (__builtin_mul_overflow(new_length, size_each, &new_size)) {
-		prlog(PR_ERR, "ERROR: Invalid size to alloc %zd * %zd\n",
-		      new_length, size_each);
+		prlog(PR_ERR, "ERROR: Invalid size to alloc %zd * %zd\n", new_length, size_each);
 		goto out;
 	}
 	*arr = realloc(*arr, size_each * new_length);

--- a/include/prlog.h
+++ b/include/prlog.h
@@ -14,10 +14,9 @@ extern int verbose;
 #define PR_PRINTF PR_NOTICE
 #define PR_INFO 6
 #define PR_DEBUG 7
-#define prlog(l, ...)                                                          \
-	do {                                                                   \
-		if (l <= MAXLEVEL)                                             \
-			fprintf((l <= PR_ERR) ? stderr : stdout,               \
-				##__VA_ARGS__);                                \
+#define prlog(l, ...)                                                                              \
+	do {                                                                                       \
+		if (l <= MAXLEVEL)                                                                 \
+			fprintf((l <= PR_ERR) ? stderr : stdout, ##__VA_ARGS__);                   \
 	} while (0)
 #endif

--- a/secvarctl.c
+++ b/secvarctl.c
@@ -11,8 +11,7 @@ static struct backend *getBackend();
 
 static struct backend backends[] = {
 	{ .name = "ibm,edk2-compat-v1",
-	  .countCmds =
-		  sizeof(edk2_compat_command_table) / sizeof(struct command),
+	  .countCmds = sizeof(edk2_compat_command_table) / sizeof(struct command),
 	  .commands = edk2_compat_command_table },
 };
 
@@ -112,14 +111,12 @@ int main(int argc, char *argv[])
  */
 static struct backend *getBackend()
 {
-	char *buff = NULL,
-	     *secVarFormatLocation = "/sys/firmware/secvar/format";
+	char *buff = NULL, *secVarFormatLocation = "/sys/firmware/secvar/format";
 	size_t buffSize;
 	struct backend *result = NULL;
 	// if file doesnt exist then print warning and keep going
 	if (isFile(secVarFormatLocation)) {
-		prlog(PR_WARNING,
-		      "WARNING!! Platform does not support secure variables\n");
+		prlog(PR_WARNING, "WARNING!! Platform does not support secure variables\n");
 		goto out;
 	}
 	buff = getDataFromFile(secVarFormatLocation, &buffSize);
@@ -131,16 +128,13 @@ static struct backend *getBackend()
 	}
 	// loop through all known backends
 	for (int i = 0; i < sizeof(backends) / sizeof(struct backend); i++) {
-		if (!strncmp(buff, backends[i].name,
-			     strlen(backends[i].name))) {
-			prlog(PR_NOTICE, "Found Backend %s\n",
-			      backends[i].name);
+		if (!strncmp(buff, backends[i].name, strlen(backends[i].name))) {
+			prlog(PR_NOTICE, "Found Backend %s\n", backends[i].name);
 			result = &backends[i];
 			goto out;
 		}
 	}
-	prlog(PR_WARNING,
-	      "WARNING!! %s  does not contain known backend format.\n",
+	prlog(PR_WARNING, "WARNING!! %s  does not contain known backend format.\n",
 	      secVarFormatLocation);
 
 out:


### PR DESCRIPTION
This series:

 - brings in compiler.h, which is pretty handy.
 - brings in edk2.h from skiboot, as it will be if my patches to the list are accepted.
 - clean up the pragma pack warnings now that edk2.h doesn't use them
 - exports some functions in skiboot and makes them accessible to secvarctl. Sadly this part is not bisectable. The skiboot side of this change was also sent to the list.