### PR TITLE
Update tests

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -14,9 +14,18 @@ else
 	MEMARGS=
 endif
 
+#run tests against secvarctl compiled with openssl
+OPENSSL = 0
+ifeq ($(OPENSSL),1)
+	OPENSSL_TESTS = "OPENSSL_TESTS_ONLY"
+else 
+	OPENSSL_TESTS =
+endif
+
 all: $(data) ../secvarctl-cov
 	$(py) runTests.py $(MEMARGS)
-	$(py) runSvcGenerateTests.py $(MEMARGS)
+	$(py) runSvcGenerateTests.py $(MEMARGS) $(OPENSSL_TESTS)
+
 	
 
 generate: $(data)

--- a/test/runSvcGenerateTests.py
+++ b/test/runSvcGenerateTests.py
@@ -328,6 +328,10 @@ class Test(unittest.TestCase):
 
 	def test_genExternalSig(self):
 		out = "genExternalSigLog.txt"
+
+		if OPENSSL:
+			command(['echo' , '"TEST NOT RAN, OPENSSL BUILDS DO NOT HAVE THIS FEATURE"' ], out, False)
+			return
 		timestamp = ["-t", "2020-1-1T1:1:1"]
 		inpCrt = "./testdata/db_by_KEK.crt"
 		sigCrt = "./testdata/goldenKeys/KEK/KEK.crt"
@@ -432,6 +436,10 @@ if __name__ == '__main__':
 	 	MEMCHECK = True
 	else: 
 	 	MEMCHECK = False
+	if 'OPENSSL_TESTS_ONLY' in sys.argv:
+		OPENSSL = True
+	else:
+		OPENSSL = False
 	del sys.argv[1:]
 	createEnvironment()
 	setupTestEnv()

--- a/test/runSvcGenerateTests.py
+++ b/test/runSvcGenerateTests.py
@@ -74,6 +74,12 @@ badSignedCommands = [
 
 ]
 
+toeslCommands=[
+[["-i", "-o", "out.esl"], False],#no input file
+[["-i", "./testdata/db_by_PK.auth", "-o"], False],#no output file
+[["-i", "./testdata/db_by_PK.auth"], False],#no output option
+]
+
 def command(args,out=None, addCMDRan=True):#stores last log of function into log file
 		if out:
 			with open(out, "w") as f:
@@ -425,6 +431,33 @@ class Test(unittest.TestCase):
 			 			self.assertEqual( getCmdResult(GEN + ["c:h", "-h", function[0], "-i", inpDir+file, "-o", outFile, "-f"], out, self), True)
 
 			 		self.assertEqual( os.path.getsize(outFile), function[1])
+	def test_authtoesl(self):
+		out="authtoesllog.txt"
+		cmd=[SECTOOLS,"generate", "a:e"]
+		inpDir = "./testdata/"
+		postUpdate="testGenerated.esl"
+		for file in os.listdir(inpDir):
+			if not file.endswith(".auth"):
+				continue;
+			file = inpDir+file
+			if file.startswith("./testdata/empty"):
+				preUpdate = "./testdata/empty.esl"
+			else:
+				preUpdate=file[:-4]+"esl"#get esl in auth
+			if file.startswith("./testdata/dbx"):
+				self.assertEqual( getCmdResult(cmd+[ "-n",  "dbx", "-i", file, "-o", postUpdate],out, self), True)#assert command runs
+			else:
+				self.assertEqual( getCmdResult(cmd+[ "-i", file, "-o", postUpdate],out, self), True)#assert command runs
+			self.assertEqual(compareFiles(preUpdate,postUpdate), True)
+		command(["rm",postUpdate])
+		for i in toeslCommands:
+			self.assertEqual( getCmdResult(cmd+i[0],out, self),i[1])
+		inpDir = './testdata/brokenFiles/'
+		for file in os.listdir(inpDir):
+			if not file.endswith(".auth"):
+				continue;
+			self.assertEqual( getCmdResult(cmd+["-i", file, "-o", postUpdate],out, self), False) #all broken auths should fail to have correct esl
+			self.assertEqual( getCmdResult(["rm",postUpdate],out, self), False) #removal of output file should fail since it was never made
 
 
 		

--- a/test/runTests.py
+++ b/test/runTests.py
@@ -102,11 +102,7 @@ validateCommands=[
 [["-p"], False],#no pkcs7
 [["-p","./testdata/db_by_PK.auth"], False],#give auth as pkcs7
 ]
-toeslCommands=[
-[["-i", "-o", "out.esl"], False],#no input file
-[["-i", "./testdata/db_by_PK.auth", "-o"], False],#no output file
-[["-i", "./testdata/db_by_PK.auth"], False],#no output option
-]
+
 badEnvCommands=[ #[arr command to skew env, output of first command, arr command for sectool, expected result]
 [["rm", "./testenv/KEK/size"],None,["read", "-p", "./testenv/", "KEK"], False], #remove size and it should fail
 [["rm", "./testenv/KEK/size"],None,["read", "-p", "./testenv/"], True], #remove size but as long as one is readable then it is ok
@@ -282,28 +278,6 @@ class Test(unittest.TestCase):
 			self.assertEqual( getCmdResult(cmd+["-p", path, "KEK",i],out, self), False)#broken auths should fail
 			self.assertEqual( getCmdResult(cmd+["-p", path ,"-f", "KEK",i],out, self), True)#if forced, they should work
 			self.assertEqual(compareFiles(i,path+"KEK/update"), True)
-	def test_authtoesl(self):
-		out="authtoesllog.txt"
-		cmd=[SECTOOLS,"generate", "a:e"]
-		for i in goodAuths:
-			file="./testdata/"+i[0]
-			if file.startswith("./testdata/empty"):
-				preUpdate = "./testdata/empty.esl"
-			else:
-				preUpdate=file[:-4]+"esl"#get esl in auth
-			postUpdate="testGenerated.esl" 
-			if file.startswith("./testdata/dbx"):
-				self.assertEqual( getCmdResult(cmd+[ "-n",  "dbx", "-i", file, "-o", postUpdate],out, self), True)#assert command runs
-			else:
-				self.assertEqual( getCmdResult(cmd+[ "-i", file, "-o", postUpdate],out, self), True)#assert command runs
-			self.assertEqual(compareFiles(preUpdate,postUpdate), True)
-		command(["rm",postUpdate])
-		for i in toeslCommands:
-			self.assertEqual( getCmdResult(cmd+i[0],out, self),i[1])
-		for i in brokenAuths:
-			postUpdate="testGenerated.esl" 
-			self.assertEqual( getCmdResult(cmd+["-i", i, "-o", postUpdate],out, self), False) #all broken auths should fail to have correct esl
-			self.assertEqual( getCmdResult(["rm",postUpdate],out, self), False) #removal of output file should fail since it was never made
 	def test_badenv(self):
 		out="badEnvLog.txt"
 		for i in badEnvCommands:


### PR DESCRIPTION
This Pull request allows CI to run successfully with secvarctl build with openssl and mbedtls. Previously, CI was failing due to some tests failing because secvarctl with openssl does not have the same features as secvarctl with mbedtls. This adds a command line flag that jenkins can use for running tests that are crypto lib dependent. Additionally, this commit moves tests that convert auths to esls from the generic python test script to the `secvarctl generate` python test script.