### PR TITLE
pkcs7.c: Respond to bug in sizeof( hash)

### DIFF
--- a/external/extraMbedtls/pkcs7.c
+++ b/external/extraMbedtls/pkcs7.c
@@ -575,7 +575,7 @@ int mbedtls_pkcs7_signed_data_verify( mbedtls_pkcs7 *pkcs7,
     mbedtls_md( md_info, data, datalen, hash );
 
     ret = mbedtls_pkcs7_signed_hash_verify( pkcs7, cert,
-                                            hash, sizeof( hash ) );
+                                            hash, 0 );
 
     mbedtls_free( hash );
 


### PR DESCRIPTION
Previously, the pkcs7 code was using sizeof(hash) in pkcs7_verify to store the size of the hash. But, since `hash` is a pointer, the incorrect value (8 instead of 32) was being passed. Mbedtls accepts 0 to use the default value for the hash function (ex: SHA256 == 32 bytes), so this commit makes use of that. Thanks to Daniel Axtens for making this observation.

Signed-off-by: Nick Child <nick.child@ibm.com>