### PR TITLE
edk2-svc-verify.c: Do not add empty secvars to variable bank

### DIFF
--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -340,8 +340,13 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 	for (int i = 0; i < currCount; i += 2) {
 		if (defaultVarsFlag) {
 			// if getting secvar successful add tmp to list
-			if (!getSecVar(&tmp, currentVars[i], currentVars[i + 1]))
-				list_add_tail(variable_bank, &tmp->link);
+			if (!getSecVar(&tmp, currentVars[i], currentVars[i + 1])) {
+				// only worth adding if it contains data
+				if (tmp->data_size > 0)
+					list_add_tail(variable_bank, &tmp->link);
+				else
+					dealloc_secvar(tmp);
+			}
 
 		} else {
 			c = getDataFromFile((char *)currentVars[i + 1], &len);

--- a/test/runTests.py
+++ b/test/runTests.py
@@ -114,7 +114,8 @@ badEnvCommands=[ #[arr command to skew env, output of first command, arr command
 [["cp","./testdata/brokenFiles/empty.esl" ,"./testenv/PK/data" ],None,["read","-p", "./testenv/"], True],# Pk will be empty but other files will have things
 [["cp","./testdata/brokenFiles/empty.esl" ,"./testenv/PK/data" ],None,["read","-p", "./testenv/", "PK"], False],# Pk will be empty, nothing else read so overall failure
 [["echo", "16"], "./testenv/TS/size", ["verify", "-v" , "-p", "./testenv/", "-u", "PK", "./testdata/PK_by_PK.auth"], False],
-[["dd", "if=/dev/zero", "of=./testenv/TS/data", "count=4", "bs=16"], None, ["verify", "-p", "./testenv/", "-u", "PK", "testdata/PK_by_PK.auth"], True] #If timestamp entry for a variable is empty than thats okay
+[["dd", "if=/dev/zero", "of=./testenv/TS/data", "count=4", "bs=16"], None, ["verify", "-p", "./testenv/", "-u", "PK", "testdata/PK_by_PK.auth"], True], #If timestamp entry for a variable is empty than thats okay
+[["echo", "0"], "./testenv/KEK/size", ["verify", "-p", "./testenv/", "-u", "db", "./testdata/db_by_PK.auth"], True] #an empty KEK should not interupt db by PK verification
 ]
 
 def command(args, out=None):#stores last log of function into log file


### PR DESCRIPTION
Previously, if an empty (size 0) secvar existed in the sysfs, it was added to the current variable bank (see `setupBanks()`). This leads to errors in `validateBanks` because it calls `validateESL` on all entries in the current variable bank. `validateESL` returns an error if there is no data in the esl. This means that if there is no data in the current KEK, the verify function will return early on an error that the contained data in KEK/data is not a valid ESL. This commit, omits empty secvars from the current list of variables since an empty secvar is a common thing in Secure Boot and should not be treated as an error.

Signed-off-by: Nick Child <nick.child@ibm.com>