### PR TITLE
Add new insert and remove subcommand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set( CMAKE_C_COMPILER gcc )
 set( SRC secvarctl.c generic.c )
 
 #sources for edk2 backend
-set ( EDK2SRC edk2-svc-read.c edk2-svc-write.c edk2-svc-validate.c edk2-svc-verify.c edk2-svc-generate.c )
+set ( EDK2SRC edk2-svc-read.c edk2-svc-write.c edk2-svc-validate.c edk2-svc-verify.c edk2-svc-generate.c edk2-svc-insert.c )
 set ( EDK2SRCDIR backends/edk2-compat/ )
 list( TRANSFORM EDK2SRC PREPEND ${EDK2SRCDIR} )
 list( APPEND SRC ${EDK2SRC} )

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ _LDFLAGS += -s
 endif
 
 EDK2OBJDIR = backends/edk2-compat
-_EDK2_OBJ =  edk2-svc-read.o edk2-svc-write.o edk2-svc-validate.o edk2-svc-verify.o edk2-svc-generate.o
+_EDK2_OBJ =  edk2-svc-read.o edk2-svc-write.o edk2-svc-validate.o edk2-svc-verify.o edk2-svc-generate.o edk2-svc-insert.o
 EDK2_OBJ = $(patsubst %,$(EDK2OBJDIR)/%, $(_EDK2_OBJ))
 
 SKIBOOTOBJDIR = external/skiboot/libstb/secvar

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
 
 
 ## USAGE:    
-  Secvarctl has 5 main commands   
+  Secvarctl has 6 main commands   
     `./secvarctl read [options] [variable]`    
     `./secvarctl write [options] <variable> <file>`    
     `./secvarctl validate [options] [fileType] <file>`  
      `./secvarctl verify [options] -u {update Variables}`  
-     `./secvarctl generate <inputFormat>:<outputFormat> [OPTIONS] -i <inputFile> -o <outputFile` 
+     `./secvarctl generate <inputFormat>:<outputFormat> [OPTIONS] -i <inputFile> -o <outputFile`  
+     `./secvarctl insert [options] {signature requirements} -i <inputFile> -o <outputFile>
 ## SUB COMMAND USAGE:
     
     READ:
@@ -218,6 +219,33 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
 		To create a variable reset file (one that will remove the current contents of a variable), replace '<inputFormat>:<outputFormat>' with 'reset' and
 		supply a variable name, public and private signer files and an output file with '-n <varName> -k <privKey> -c <crtFile> -o <outFile>'
 		GENERATION OF PKCS7 AND AUTH FILES ARE IN EXPERIMENTAL DEVELEPOMENT PHASE. THEY HAVE NOT BEEN THOROUGHLY TESTED YET.
+
+        INSERT:
+            ./secvarctl insert {signing requirements} -i <inputFile> -o <outputFile>
+            OR
+            ./secvarctl insert {signing requirements} -i <inputFile> -w
+        REQUIRED:
+            -i <inputFile> , the new esl to be appended
+            -w , submit update by writing output to secvar `update` file
+            -o <outputFile>, alternative to -w, write output auth to file
+            signing requirements (see GENERATE):
+                -c <certFile>
+                -k <privKey> OR -s <sigFile>
+                -n <varName>
+        OPTIONAL:
+            --usage
+            --help
+            -v , verbose, gives process info
+            -t <time> , see GENERATE for decription
+            -f , force, do not do validate file formats
+            -e <esl> , specify current ESL to append data to, default is <PATH>/<VAR_NAME>/data
+            -p <path> , specify path to current secvars, default is /sys/firmware/secvar/vars
+
+        The insert command is used to add an ESL entry to a current ESL chain. This command is useful since a secure variable update will completely replace the previous data of that secvar. 
+        By using the insert command, the user can add a new ESL to the secvar while maintaining its current entries. The process invlolves adding a new ESL to the current ESL, and 
+        generating an auth file with the combined ESL. The resulting auth file can be either submitted as a secvar update (with '-w') or output to a file (with '-o'). By default, the current esl is read from the secvar path, but a user given ESL chain can be used with the '-e' option. The secvar path that is used for reading the current ESL and writing the ouput auth (if '-w' is present), can be set to a user defined path with '-p'. If, the '-f' flag is given, the new, current and combined ESL will not be checked for format correctness. Since an auth file is being generated, all required flags for auth generation from the 'secvarctl generate' command are needed, this includes '-k/-s', '-c', '-n'. The '-t' flag has also been used to allow the user to specify the timestamp to use in the auth file metadata.
+
+
 
       
 ## License   

--- a/README.md
+++ b/README.md
@@ -56,13 +56,14 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
 
 
 ## USAGE:    
-  Secvarctl has 6 main commands   
+  Secvarctl has 7 main commands   
     `./secvarctl read [options] [variable]`    
     `./secvarctl write [options] <variable> <file>`    
     `./secvarctl validate [options] [fileType] <file>`  
      `./secvarctl verify [options] -u {update Variables}`  
      `./secvarctl generate <inputFormat>:<outputFormat> [OPTIONS] -i <inputFile> -o <outputFile`  
-     `./secvarctl insert [options] {signature requirements} -i <inputFile> -o <outputFile>
+     `./secvarctl insert [options] {signature requirements} -i <inputFile> -o <outputFile>`     
+      `./secvarctl remove [options] {signature requirements} -x <serial_number> -o <outputFile>`    
 ## SUB COMMAND USAGE:
     
     READ:
@@ -219,12 +220,11 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
 		To create a variable reset file (one that will remove the current contents of a variable), replace '<inputFormat>:<outputFormat>' with 'reset' and
 		supply a variable name, public and private signer files and an output file with '-n <varName> -k <privKey> -c <crtFile> -o <outFile>'
 		GENERATION OF PKCS7 AND AUTH FILES ARE IN EXPERIMENTAL DEVELEPOMENT PHASE. THEY HAVE NOT BEEN THOROUGHLY TESTED YET.
-
-        INSERT:
+    INSERT:
             ./secvarctl insert {signing requirements} -i <inputFile> -o <outputFile>
             OR
             ./secvarctl insert {signing requirements} -i <inputFile> -w
-        REQUIRED:
+    REQUIRED:
             -i <inputFile> , the new esl to be appended
             -w , submit update by writing output to secvar `update` file
             -o <outputFile>, alternative to -w, write output auth to file
@@ -232,7 +232,7 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
                 -c <certFile>
                 -k <privKey> OR -s <sigFile>
                 -n <varName>
-        OPTIONAL:
+    OPTIONAL:
             --usage
             --help
             -v , verbose, gives process info
@@ -245,6 +245,51 @@ For any questions regarding secvarctl, feel free to reach out: [Nick Child](nick
         By using the insert command, the user can add a new ESL to the secvar while maintaining its current entries. The process invlolves adding a new ESL to the current ESL, and 
         generating an auth file with the combined ESL. The resulting auth file can be either submitted as a secvar update (with '-w') or output to a file (with '-o'). By default, the current esl is read from the secvar path, but a user given ESL chain can be used with the '-e' option. The secvar path that is used for reading the current ESL and writing the ouput auth (if '-w' is present), can be set to a user defined path with '-p'. If, the '-f' flag is given, the new, current and combined ESL will not be checked for format correctness. Since an auth file is being generated, all required flags for auth generation from the 'secvarctl generate' command are needed, this includes '-k/-s', '-c', '-n'. The '-t' flag has also been used to allow the user to specify the timestamp to use in the auth file metadata.
 
+    REMOVE:
+            ./secvarctl remove {signing requirements} -x <serial_number> -o <outputFile>
+            OR
+            ./secvarctl remove {signing requirements} -x <serial_number> -w
+    REQUIRED:
+            -x <serial_number> , the serial number in the X509 of the
+                ESL to remove from the current esl. If variable being up‐
+                dated is dbx, then this is a hash instead of a serial
+                number
+            -w , submit update by writing output to secvar `update` file
+            -o <outputFile>, alternative to -w, write output auth to file
+            signing requirements (see GENERATE):
+                -c <certFile>
+                -k <privKey> OR -s <sigFile>
+                -n <varName>
+    OPTIONAL:
+            --usage
+            --help
+            -v , verbose, gives process info
+            -t <time> , see GENERATE for decription
+            -f , force, do not do validate file formats
+            -e <esl> , specify current ESL to remove data from, default is <PATH>/<VAR_NAME>/data
+            -p <path> , specify path to current secvars, default is /sys/firmware/secvar/vars
+
+              This command will remove an ESL entry from a secvars current
+              list of ESLs. This is useful if the user would like to delete
+              only a portion of the secure variables data  without completely
+              removing it (for this use secvarctl generate reset ). This com‐
+              mand is very similar to secvarctl insert except instead of using
+              the -i flag to recieve a new ESL, the remove command uses -x
+              <serial_number> to identify the ESL which is to be removed. All
+              of  the other arguments -o, -w, -e, -p, -f, -k/s, -c, -k, -n, -t
+              are identical to their use in secvarctl insert command. The  ar‐
+              gument -x <serial_number> is required and must contain a valid
+              20 byte serial number that is contained in an X509 of one of the
+              ESL's in the current secure variable. The format of this serial
+              number must be in hexadecimal octets seperated by a ':' . To see
+              the serial numbers in an ESL, either secvarctl read or secvarctl
+              validate -v -e <esl_file> can be used. Since the dbx variable
+              does not contain X509's, the -x <serial_number> argument can ac‐
+              cept a hash instead. This hash must be one of the  hashes  being
+              stored in one of the dbx's ESLs. The format of the argument is
+              the same and finding available hashes to  extract  can  be  done
+              with either the secvarctl read dbx or secvarctl validate -v -x
+              -e <esl_file> commands.
 
 
       

--- a/backends/edk2-compat/edk2-svc-generate.c
+++ b/backends/edk2-compat/edk2-svc-generate.c
@@ -25,19 +25,15 @@ static int generateHash(const unsigned char *data, size_t size, struct Arguments
 static int validateHashAndAlg(size_t size, const struct hash_funct *alg);
 static int toESL(const unsigned char *data, size_t size, const uuid_t guid, unsigned char **outESL,
 		 size_t *outESLSize);
-static int getHashFunction(const char *name, struct hash_funct **returnFunct);
 static int toPKCS7ForSecVar(const unsigned char *newData, size_t dataSize,
 			    struct Auth_specific_args *args, int hashFunct, unsigned char **outBuff,
 			    size_t *outBuffSize);
-static int toAuth(const unsigned char *newESL, size_t eslSize, struct Auth_specific_args *args,
-		  int hashFunct, unsigned char **outBuff, size_t *outBuffSize);
 static int generateESL(const unsigned char *buff, size_t size, struct Arguments *args,
 		       const struct hash_funct *hashFunct, unsigned char **outBuff,
 		       size_t *outBuffSize);
 static int generateAuthOrPKCS7(const unsigned char *buff, size_t size, struct Arguments *args,
 			       const struct hash_funct *hashFunct, unsigned char **outBuff,
 			       size_t *outBuffSize);
-static int getTimestamp(struct efi_time *ts);
 static int getOutputData(const unsigned char *buff, size_t size, struct Arguments *args,
 			 const struct hash_funct *hashFunction, unsigned char **outBuff,
 			 size_t *outBuffSize);
@@ -158,7 +154,7 @@ static int auth_specific_parse_opt(int key, char *arg, struct argp_state *state)
 
 struct argp gen_auth_specific_argp = { auth_specific_argp_options, auth_specific_parse_opt, 0, 0,
 				       0 };
-struct argp_child gen_auth_specific_child_parsers[] = {
+static struct argp_child gen_auth_specific_child_parsers[] = {
 	{ &gen_auth_specific_argp, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP,
 	  "Generating Auth/PKCS7 Options:", 7 },
 	{ 0 }
@@ -852,7 +848,7 @@ static int authToESL(const unsigned char *in, size_t inSize, unsigned char **out
  *@param returnFunct, the corresponding hash_funct info array
  *@return SUCCESS or err number if not a valid hash function name
  */
-static int getHashFunction(const char *name, struct hash_funct **returnFunct)
+int getHashFunction(const char *name, struct hash_funct **returnFunct)
 {
 	for (int i = 0; i < sizeof(hash_functions) / sizeof(struct hash_funct); i++) {
 		if (!strcmp(name, hash_functions[i].name)) {
@@ -892,7 +888,7 @@ static void convert_tm_to_efi_time(struct efi_time *efi_t, struct tm *tm_t)
  *@param ts, the outputted current time
  *@return SUCCESS or errno if generated timestamp is incorrect
  */
-static int getTimestamp(struct efi_time *ts)
+int getTimestamp(struct efi_time *ts)
 {
 	time_t epochTime;
 	struct tm *t;
@@ -1093,8 +1089,8 @@ out:
  *@param outBuffSize, the length of outBuff
  *@return SUCCESS or err number 
  */
-static int toAuth(const unsigned char *newESL, size_t eslSize, struct Auth_specific_args *args,
-		  int hashFunct, unsigned char **outBuff, size_t *outBuffSize)
+int toAuth(const unsigned char *newESL, size_t eslSize, struct Auth_specific_args *args,
+	   int hashFunct, unsigned char **outBuff, size_t *outBuffSize)
 {
 	int rc;
 	size_t pkcs7Size, offset = 0;

--- a/backends/edk2-compat/edk2-svc-insert.c
+++ b/backends/edk2-compat/edk2-svc-insert.c
@@ -31,7 +31,7 @@ struct Arguments {
 	int help_flag, inp_valid;
 	enum output_method output_method;
 	enum input_method input_method;
-	const char *new_esl, *out_file, *current_esl, *hash_alg, *path_to_sec_vars;
+	const char *new_esl, *out_file, *current_esl, *path_to_sec_vars;
 	struct Auth_specific_args auth_args;
 };
 static struct argp_child gen_auth_specific_child_parsers[] = {
@@ -51,7 +51,6 @@ int performInsertCommand(int argc, char *argv[])
 {
 	int rc;
 	size_t out_buff_size, new_esl_size, curr_esl_size, combined_esl_size;
-	struct hash_funct *hash_function;
 	unsigned char *new_esl_buff = NULL, *current_esl_buff = NULL, *combined_esl_buff = NULL,
 		      *out_buff = NULL;
 	struct Arguments args = { .help_flag = 0,
@@ -60,7 +59,6 @@ int performInsertCommand(int argc, char *argv[])
 				  .input_method = READ_FROM_SECVAR_PATH,
 				  .new_esl = NULL,
 				  .current_esl = NULL,
-				  .hash_alg = NULL,
 				  .path_to_sec_vars = NULL,
 				  .auth_args = { .signKeyCount = 0,
 						 .signCertCount = 0,
@@ -73,9 +71,6 @@ int performInsertCommand(int argc, char *argv[])
 	argv[0] = "secvarctl insert";
 
 	struct argp_option options[] = {
-		{ "alg", 'h', "HASH_ALG", 0,
-		  "hash function, use when validating input ESL for dbx"
-		  " currently accepted values: {'SHA256', 'SHA224', 'SHA1', 'SHA384', 'SHA512'}, Default is 'SHA256'" },
 		{ "verbose", 'v', 0, 0, "print more verbose process information" },
 		{ "force", 'f', 0, 0,
 		  "does not do prevalidation on the input file, assumes format is correct" },
@@ -110,15 +105,6 @@ int performInsertCommand(int argc, char *argv[])
 
 	/*fill in fields w/ default data*/
 
-	if (strcmp(args.auth_args.varName, "dbx") == 0) {
-		// default alg is sha256
-		if (args.hash_alg == NULL)
-			args.hash_alg = "SHA256";
-		// get hash function
-		rc = getHashFunction(args.hash_alg, &hash_function);
-		if (rc)
-			goto out;
-	}
 	if (args.auth_args.time == NULL) {
 		args.auth_args.time = calloc(1, sizeof(*args.auth_args.time));
 		if (!args.auth_args.time) {
@@ -296,9 +282,6 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		break;
 	case 'p':
 		args->path_to_sec_vars = arg;
-		break;
-	case 'h':
-		args->hash_alg = arg;
 		break;
 	case ARGP_KEY_INIT:
 		// for first loop around argp requires us to specify which data struct to use for child parsers

--- a/backends/edk2-compat/edk2-svc-insert.c
+++ b/backends/edk2-compat/edk2-svc-insert.c
@@ -53,13 +53,16 @@ static struct argp_option insert_and_remove_shared_argp_options[] = {
 	{ "path", 'p', "PATH", 0,
 	  "specify path to current secvars, default is " SECVARPATH
 	  " expects subdirectory <PATH>/<VAR_NAME> to exist" },
-	// these are hidden because they are mandatory and are described in the help message instead of in the options
-	{ 0, 'o', "FILE", OPTION_HIDDEN, "output file" },
-	{ 0, 'w', 0, OPTION_HIDDEN, "write to secvars" },
+	//  since mandatory we use OPTION_NO_USAGE which means they appear in the help message but not usage
+	{ 0, 'o', "FILE", OPTION_NO_USAGE,
+	  "output file, output will be an auth file, either this or '-w' is required" },
+	{ "--write", 'w', 0, OPTION_NO_USAGE,
+	  "if successful, submit output as secvar update, path to secvars is assigned with '-p'" },
 	{ "help", '?', 0, 0, "Give this help list", 1 },
 	{ "usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
 	{ 0 }
 };
+
 /**
  *shared parser for both insert and remove command, this parser also has a child parser that parses auth generation flags
  *@param key , every option that is parsed has a value to identify it
@@ -186,8 +189,8 @@ int performInsertCommand(int argc, char *argv[])
 	argv[0] = "secvarctl insert";
 
 	struct argp_option options[] = {
-		// these are hidden because they are mandatory and are described in the help message instead of in the options
-		{ 0, 'i', "FILE", OPTION_HIDDEN, "input ESL file to add to current ESL" },
+		{ 0, 'i', "FILE", OPTION_NO_USAGE,
+		  "required input file, constains new ESL to add to current ESL" },
 		{ 0 }
 	};
 
@@ -199,7 +202,6 @@ int performInsertCommand(int argc, char *argv[])
 		" The default location of secvars is " SECVARPATH ", use '-p' for other paths."
 		" At the moment only files containing ESL's are acceptable as input. To generate an ESL, see 'secvarctl generate --help'. ",
 		insert_remove_shared_child_parsers
-
 	};
 
 	rc = argp_parse(&argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);

--- a/backends/edk2-compat/edk2-svc-insert.c
+++ b/backends/edk2-compat/edk2-svc-insert.c
@@ -1,0 +1,347 @@
+/* Copyright 2021 IBM Corp.*/
+#ifndef NO_CRYPTO
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#define __USE_XOPEN // needed for strptime
+#include <time.h> // for timestamp
+#include <ctype.h> // for isspace
+#include <argp.h>
+#include "libstb/secvar/crypto/crypto.h"
+#include "backends/edk2-compat/include/edk2-svc.h"
+
+/*An `insert` command must always accept a new ESL file but it can append it to either an ESL from
+ *any of the following means of input:
+ *      1. the default secvar sysfs path
+ *      2. a user defined path to secvars
+ *      3. a user given file
+ *Additionally, the final signed auth w appended new ESL can be output to any of the above locations
+ *The goal is to input and output ESLs with any combination of the above methods
+ *Therefore, there are about 9 applications of the insert command
+ */
+static int parse_opt(int key, char *arg, struct argp_state *state);
+
+/*the following enums are to keep track of the different applications of this command*/
+enum output_method { NO_SELECTION = 0, SUBMIT_AS_SECVAR_UPDATE, WRITE_TO_FILE };
+enum input_method { READ_FROM_SECVAR_PATH = 0, READ_FROM_FILE };
+
+struct Arguments {
+	// the optionalOutFile is used if output_method is WRITE_TO_FILE
+	// the optionalInFile is used if input_method is READ_FROM_FILE
+	int help_flag, inp_valid;
+	enum output_method output_method;
+	enum input_method input_method;
+	const char *new_esl, *out_file, *current_esl, *hash_alg, *path_to_sec_vars;
+	struct Auth_specific_args auth_args;
+};
+static struct argp_child gen_auth_specific_child_parsers[] = {
+	{ &gen_auth_specific_argp, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP,
+	  "Auth Generation Options", 7 },
+	{ 0 }
+};
+
+/*
+ *called from main()
+ *handles argument parsing for insert command
+ *@param argc, number of argument
+ *@param arv, array of params
+ *@return SUCCESS or err number 
+ */
+int performInsertCommand(int argc, char *argv[])
+{
+	int rc;
+	size_t out_buff_size, new_esl_size, curr_esl_size, combined_esl_size;
+	struct hash_funct *hash_function;
+	unsigned char *new_esl_buff = NULL, *current_esl_buff = NULL, *combined_esl_buff = NULL,
+		      *out_buff = NULL;
+	struct Arguments args = { .help_flag = 0,
+				  .inp_valid = 0,
+				  .output_method = NO_SELECTION,
+				  .input_method = READ_FROM_SECVAR_PATH,
+				  .new_esl = NULL,
+				  .current_esl = NULL,
+				  .hash_alg = NULL,
+				  .path_to_sec_vars = NULL,
+				  .auth_args = { .signKeyCount = 0,
+						 .signCertCount = 0,
+						 .signCerts = NULL,
+						 .signKeys = NULL,
+						 .varName = NULL,
+						 .time = NULL,
+						 .pkcs7_gen_meth = NO_PKCS7_GEN_METHOD } };
+	// combine command and subcommand for usage/help messages
+	argv[0] = "secvarctl insert";
+
+	struct argp_option options[] = {
+		{ "alg", 'h', "HASH_ALG", 0,
+		  "hash function, use when validating input ESL for dbx"
+		  " currently accepted values: {'SHA256', 'SHA224', 'SHA1', 'SHA384', 'SHA512'}, Default is 'SHA256'" },
+		{ "verbose", 'v', 0, 0, "print more verbose process information" },
+		{ "force", 'f', 0, 0,
+		  "does not do prevalidation on the input file, assumes format is correct" },
+		{ "esl", 'e', "FILE", 0,
+		  "specify current ESL to append data to, default is to <PATH>/<VAR_NAME>/data" },
+		{ "path", 'p', "PATH", 0,
+		  "specify path to current secvars, default is " SECVARPATH
+		  " expects subdirectory <PATH>/<VAR_NAME> to exist" },
+		// these are hidden because they are mandatory and are described in the help message instead of in the options
+		{ 0, 'i', "FILE", OPTION_HIDDEN, "input ESL file to add to current ESL" },
+		{ 0, 'o', "FILE", OPTION_HIDDEN, "output file" },
+		{ 0, 'w', 0, OPTION_HIDDEN, "write to secvars" },
+		{ "help", '?', 0, 0, "Give this help list", 1 },
+		{ "usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
+		{ 0 }
+	};
+
+	struct argp argp = {
+		options, parse_opt,
+		"-n <var_name> -k/-s <key/sig> -c <crt> -i <new_esl> -o <out_file>\n-n <var_name> -k/-s <key/sig> -c <crt> -i <new_esl> -w",
+		"This command appends an ESL to a current chain of ESL's and uses it to generate an valid Auth"
+		" file. The generated Auth can be output to a file with '-o' or submited as a secvar update with '-w'."
+		" The default location of secvars is " SECVARPATH ", use '-p' for other paths."
+		" At the moment only files containing ESL's are acceptable as input. To generate an ESL, see 'secvarctl generate --help'. ",
+		gen_auth_specific_child_parsers
+
+	};
+
+	rc = argp_parse(&argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
+	if (rc || args.help_flag)
+		goto out;
+
+	/*fill in fields w/ default data*/
+
+	if (strcmp(args.auth_args.varName, "dbx") == 0) {
+		// default alg is sha256
+		if (args.hash_alg == NULL)
+			args.hash_alg = "SHA256";
+		// get hash function
+		rc = getHashFunction(args.hash_alg, &hash_function);
+		if (rc)
+			goto out;
+	}
+	if (args.auth_args.time == NULL) {
+		args.auth_args.time = calloc(1, sizeof(*args.auth_args.time));
+		if (!args.auth_args.time) {
+			prlog(PR_ERR, "ERROR: failed to allocate memory\n");
+			rc = ALLOC_FAIL;
+			goto out;
+		}
+		rc = getTimestamp(args.auth_args.time);
+		if (rc)
+			goto out;
+	}
+	// if no custom path to secvars, use default
+	if (args.path_to_sec_vars == NULL)
+		args.path_to_sec_vars = SECVARPATH;
+
+	// generate helpful info string
+	prlog(PR_INFO, "New ESL %s, being appended to ", args.new_esl);
+	if (args.input_method == READ_FROM_SECVAR_PATH)
+		prlog(PR_INFO, "%s%s/data", args.path_to_sec_vars, args.auth_args.varName);
+	else
+		prlog(PR_INFO, "%s", args.current_esl);
+	prlog(PR_INFO, ", will be output to ");
+	if (args.output_method == SUBMIT_AS_SECVAR_UPDATE)
+		prlog(PR_INFO, "%s%s/update\n", args.path_to_sec_vars, args.auth_args.varName);
+	else
+		prlog(PR_INFO, "%s\n", args.out_file);
+
+	//arg parsing, debug printing is done, now start process
+	// 1. get new ESL
+	new_esl_buff = (unsigned char *)getDataFromFile(args.new_esl, SIZE_MAX, &new_esl_size);
+	if (new_esl_buff == NULL) {
+		rc = INVALID_FILE;
+		goto out;
+	}
+	if (!args.inp_valid) {
+		prlog(PR_INFO, "Validating new ESL...\n");
+		rc = validateESL(new_esl_buff, new_esl_size, args.auth_args.varName);
+		if (rc) {
+			prlog(PR_ERR, "ERROR: Could not validate new ESL\n");
+			goto out;
+		}
+	}
+	// 2. get current esl from either getsecvar or read file
+	if (args.input_method == READ_FROM_SECVAR_PATH)
+		rc = getDataFromSecVar((char **)&current_esl_buff, &curr_esl_size,
+				       args.path_to_sec_vars, args.auth_args.varName);
+	else {
+		current_esl_buff =
+			(unsigned char *)getDataFromFile(args.current_esl, SIZE_MAX, &curr_esl_size);
+		if (current_esl_buff == NULL)
+			rc = INVALID_FILE;
+	}
+	if (rc) {
+		prlog(PR_ERR, "ERROR: Could not get current ESL\n");
+		goto out;
+	}
+	if (!args.inp_valid) {
+		prlog(PR_INFO, "Validating current ESL...\n");
+		rc = validateESL(current_esl_buff, curr_esl_size, args.auth_args.varName);
+		if (rc) {
+			prlog(PR_ERR, "ERROR: Could not validate current ESL\n");
+			goto out;
+		}
+	}
+	// 4. append the twos
+	combined_esl_size = curr_esl_size + new_esl_size;
+	combined_esl_buff = malloc(combined_esl_size);
+	if (!combined_esl_buff) {
+		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
+		rc = ALLOC_FAIL;
+		goto out;
+	}
+	prlog(PR_INFO, "Copying %lu bytes from current esl...\n", curr_esl_size);
+	memcpy(combined_esl_buff, current_esl_buff, curr_esl_size);
+	prlog(PR_INFO, "Copying %lu bytes from new esl...\n", new_esl_size);
+	memcpy(combined_esl_buff + curr_esl_size, new_esl_buff, new_esl_size);
+	if (args.inp_valid)
+		prlog(PR_INFO,
+		      "Generated ESL with %lu bytes, skipping validation ('-f' flag detected)\n",
+		      combined_esl_size);
+	else {
+		prlog(PR_INFO, "Validating new appended ESL of %lu bytes...\n", combined_esl_size);
+		rc = validateESL(combined_esl_buff, combined_esl_size, args.auth_args.varName);
+		if (rc) {
+			prlog(PR_ERR,
+			      "ERROR: Failed to generate a valid ESL by appending current and new ESLs\n");
+			goto out;
+		}
+		prlog(PR_INFO, "Validating new  appended ESL successfull\n");
+	}
+	// 5. generate auth
+	rc = toAuth(combined_esl_buff, combined_esl_size, &(args.auth_args), 42, &out_buff,
+		    &out_buff_size);
+	if (rc) {
+		prlog(PR_ERR, "Failed to generate auth file with new appended ESL\n");
+		goto out;
+	}
+	prlog(PR_INFO, "Auth generation successful\n");
+	// 6. write file or write to secvars
+	if (args.output_method == SUBMIT_AS_SECVAR_UPDATE) {
+		prlog(PR_INFO, "Submitting secvar update...\n");
+		rc = updateVar(args.path_to_sec_vars, args.auth_args.varName, out_buff,
+			       out_buff_size);
+		if (rc)
+			prlog(PR_ERR, "Failed to submit as secvar update\n");
+	} else if (args.output_method == WRITE_TO_FILE) {
+		prlog(PR_INFO, "Writing to file %s...\n", args.out_file);
+		rc = createFile(args.out_file, (char *)out_buff, out_buff_size);
+		if (rc) {
+			prlog(PR_ERR, "ERROR: Could not write new data to output file %s\n",
+			      args.out_file);
+		}
+	}
+
+out:
+	if (new_esl_buff)
+		free(new_esl_buff);
+	if (out_buff)
+		free(out_buff);
+	if (current_esl_buff)
+		free(current_esl_buff);
+	if (combined_esl_buff)
+		free(combined_esl_buff);
+	if (args.auth_args.signKeys)
+		free(args.auth_args.signKeys);
+	if (args.auth_args.signCerts)
+		free(args.auth_args.signCerts);
+	if (args.auth_args.time)
+		free(args.auth_args.time);
+	if (!args.help_flag)
+		printf("RESULT: %s\n", rc ? "FAILURE" : "SUCCESS");
+
+	return rc;
+}
+
+/**
+ *@param key , every option that is parsed has a value to identify it
+ *@param arg, if key is an option than arg will hold its value ex: -<key> <arg>
+ *@param state,  argp_state struct that contains useful information about the current parsing state 
+ *@return success or errno
+ */
+static int parse_opt(int key, char *arg, struct argp_state *state)
+{
+	struct Arguments *args = state->input;
+	int rc = SUCCESS;
+
+	switch (key) {
+	case '?':
+		args->help_flag = 1;
+		argp_state_help(state, stdout, ARGP_HELP_STD_HELP);
+		break;
+	case ARGP_OPT_USAGE_KEY:
+		args->help_flag = 1;
+		argp_state_help(state, stdout, ARGP_HELP_USAGE);
+		break;
+	case 'f':
+		args->inp_valid = 1;
+		break;
+	case 'v':
+		verbose = PR_DEBUG;
+		break;
+	case 'i':
+		args->new_esl = arg;
+		break;
+	case 'o':
+		args->output_method = WRITE_TO_FILE;
+		args->out_file = arg;
+		break;
+	case 'w':
+		args->output_method = SUBMIT_AS_SECVAR_UPDATE;
+		break;
+	case 'e':
+		args->input_method = READ_FROM_FILE;
+		args->current_esl = arg;
+		break;
+	case 'p':
+		args->path_to_sec_vars = arg;
+		break;
+	case 'h':
+		args->hash_alg = arg;
+		break;
+	case ARGP_KEY_INIT:
+		// for first loop around argp requires us to specify which data struct to use for child parsers
+		state->child_inputs[0] = &(args->auth_args);
+		break;
+	case ARGP_KEY_SUCCESS:
+		// check that all essential args are given and valid
+		if (args->help_flag)
+			break;
+		else if (args->auth_args.time && validateTime(args->auth_args.time))
+			prlog(PR_ERR,
+			      "Invalid timestamp flag '-t YYYY-MM-DDThh:mm:ss' , see usage...\n");
+		else if (args->new_esl == NULL || isFile(args->new_esl))
+			prlog(PR_ERR, "ERROR: Input file is invalid, see usage below...\n");
+		else if (args->auth_args.varName == NULL || isVariable(args->auth_args.varName) ||
+			 strcmp(args->auth_args.varName, "TS") == 0)
+			prlog(PR_ERR, "ERROR: Invalid variable name, see usage below\n");
+		else if (args->output_method == NO_SELECTION)
+			prlog(PR_ERR,
+			      "ERROR: No output selction given, use either '-w' or ''-o', see usage below...\n");
+		else if (args->auth_args.signCertCount == 0)
+			prlog(PR_ERR,
+			      "ERROR: At least one certificate needed, use '-c', see usage below...\n");
+		else if (args->auth_args.signKeyCount == 0)
+			prlog(PR_ERR,
+			      "ERROR: At least one private key/signature needed, use '-k'/'-s', see usage below...\n");
+		//each signer needs a certificate
+		else if (args->auth_args.signCertCount != args->auth_args.signKeyCount)
+			prlog(PR_ERR,
+			      "ERROR: Number of certificates does not equal number of %s files, %d != %d, see usage below...\n",
+			      args->auth_args.pkcs7_gen_meth == W_EXTERNAL_GEN_SIG ? "signature" :
+											   "private key",
+			      args->auth_args.signCertCount, args->auth_args.signKeyCount);
+		else
+			break;
+		argp_usage(state);
+		rc = ARG_PARSE_FAIL;
+		break;
+	}
+
+	if (rc)
+		prlog(PR_ERR, "Failed during argument parsing\n");
+
+	return rc;
+}
+#endif

--- a/backends/edk2-compat/edk2-svc-insert.c
+++ b/backends/edk2-compat/edk2-svc-insert.c
@@ -116,9 +116,18 @@ static int insert_and_remove_shared_parse_opt(int key, char *arg, struct argp_st
 		else if (args->auth_args.time && validateTime(args->auth_args.time))
 			prlog(PR_ERR,
 			      "Invalid timestamp flag '-t YYYY-MM-DDThh:mm:ss' , see usage...\n");
-		else if (args->auth_args.varName == NULL || isVariable(args->auth_args.varName) ||
-			 strcmp(args->auth_args.varName, "TS") == 0)
+		else if (args->auth_args.varName == NULL || isVariable(args->auth_args.varName))
 			prlog(PR_ERR, "ERROR: Invalid variable name, see usage below\n");
+		else if (strcmp(args->auth_args.varName, "TS") == 0)
+			prlog(PR_ERR,
+			      "ERROR: TS is not a valid secvar for editing, see usage below...\n");
+		// not sure if dbx entries are all in one ESL or a chain of single entry ESL's
+		// TODO
+		// seriously come back to this, we are reading dbx's as one per ESL w/ many appended ESLs. is this true?
+		else if (strlen(args->auth_args.varName) > 2 &&
+			 strcmp(args->auth_args.varName, "dbx") == 0)
+			prlog(PR_ERR,
+			      "ERROR: insert/removing entries from dbx not implemented yet, see usage below...\n");
 		else if (args->output_method == NO_SELECTION)
 			prlog(PR_ERR,
 			      "ERROR: No output selction given, use either '-w' or ''-o', see usage below...\n");

--- a/backends/edk2-compat/edk2-svc-insert.c
+++ b/backends/edk2-compat/edk2-svc-insert.c
@@ -126,13 +126,6 @@ static int insert_and_remove_shared_parse_opt(int key, char *arg, struct argp_st
 		else if (strcmp(args->auth_args.varName, "TS") == 0)
 			prlog(PR_ERR,
 			      "ERROR: TS is not a valid secvar for editing, see usage below...\n");
-		// not sure if dbx entries are all in one ESL or a chain of single entry ESL's
-		// TODO
-		// seriously come back to this, we are reading dbx's as one per ESL w/ many appended ESLs. is this true?
-		else if (strlen(args->auth_args.varName) > 2 &&
-			 strcmp(args->auth_args.varName, "dbx") == 0)
-			prlog(PR_ERR,
-			      "ERROR: insert/removing entries from dbx not implemented yet, see usage below...\n");
 		else if (args->output_method == NO_SELECTION)
 			prlog(PR_ERR,
 			      "ERROR: No output selction given, use either '-w' or ''-o', see usage below...\n");

--- a/backends/edk2-compat/edk2-svc-insert.c
+++ b/backends/edk2-compat/edk2-svc-insert.c
@@ -9,6 +9,8 @@
 #include <argp.h>
 #include "libstb/secvar/crypto/crypto.h"
 #include "backends/edk2-compat/include/edk2-svc.h"
+#include "external/skiboot/libstb/secvar/secvar.h" // for secvar struct
+
 
 /* child parser for insert and removes child parser */
 static struct argp_child gen_auth_specific_child_parsers[] = {
@@ -27,6 +29,9 @@ static struct argp_child gen_auth_specific_child_parsers[] = {
  *Therefore, there are about 9 applications of the insert command
  */
 static int insert_specific_parse_opt(int key, char *arg, struct argp_state *state);
+/*A `remove` command works similary to the above `insert` command comment except the input is a serial number not an ESL */
+static int remove_specific_parse_opt(int key, char *arg, struct argp_state *state);
+
 
 /*the following enums are to keep track of the different applications of this command*/
 enum output_method { NO_SELECTION = 0, SUBMIT_AS_SECVAR_UPDATE, WRITE_TO_FILE };
@@ -49,14 +54,14 @@ static struct argp_option insert_and_remove_shared_argp_options[] = {
 	{ "force", 'f', 0, 0,
 	  "does not do prevalidation on the input file, assumes format is correct" },
 	{ "esl", 'e', "FILE", 0,
-	  "specify current ESL to append data to, default is to <PATH>/<VAR_NAME>/data" },
+	  "specify current ESL to append/remove data to, default is to <PATH>/<VAR_NAME>/data" },
 	{ "path", 'p', "PATH", 0,
 	  "specify path to current secvars, default is " SECVARPATH
 	  " expects subdirectory <PATH>/<VAR_NAME> to exist" },
 	//  since mandatory we use OPTION_NO_USAGE which means they appear in the help message but not usage
 	{ 0, 'o', "FILE", OPTION_NO_USAGE,
 	  "output file, output will be an auth file, either this or '-w' is required" },
-	{ "--write", 'w', 0, OPTION_NO_USAGE,
+	{ "write", 'w', 0, OPTION_NO_USAGE,
 	  "if successful, submit output as secvar update, path to secvars is assigned with '-p'" },
 	{ "help", '?', 0, 0, "Give this help list", 1 },
 	{ "usage", ARGP_OPT_USAGE_KEY, 0, 0, "Give a short usage message", -1 },
@@ -391,4 +396,344 @@ static int insert_specific_parse_opt(int key, char *arg, struct argp_state *stat
 
 	return rc;
 }
+
+static int convert_ascii_hex_to_raw_hex(const char *ascii, unsigned char *raw, size_t raw_len)
+{
+	char *tmp_hex = NULL;
+	char *end_ptr = NULL;
+	char *ascii_cpy = NULL;
+	
+	ascii_cpy = malloc(strlen(ascii) + 1);
+	if (!ascii_cpy) {
+		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
+		return ALLOC_FAIL;
+	}
+	memcpy(ascii_cpy, ascii, strlen(ascii) + 1);
+	for (int i = 0; i < raw_len; i++) {
+		if (i == 0)
+			tmp_hex = strtok(ascii_cpy, ":");
+		else
+			tmp_hex = strtok(NULL, ":");
+		if (!tmp_hex || strlen(tmp_hex) != 2) {
+			prlog(PR_ERR, "ERROR: Failed to parse given serial number %s, unparsed string segment = %s\n",
+						ascii, ascii + (3*i) );
+			free(ascii_cpy);
+			return ARG_PARSE_FAIL;
+		}
+		raw[i] = (unsigned char) strtoul(tmp_hex, &end_ptr, 16);
+		if (*end_ptr != '\0'){
+			prlog(PR_ERR, "Parsing %s segment of serial %s failed\n", tmp_hex, ascii);
+			free(ascii_cpy);
+			return ARG_PARSE_FAIL;
+		}
+	}
+	free(ascii_cpy);
+	return SUCCESS;
+}
+// WHERE NICK LEFT OFF, NOT COMPILING, CHECK FORMAT OF RETURNED SERIAL NUMBER, CLEANUP RETURN CODE
+/*
+ *removes an ESL from a chain of ESLs and returns the ESL without the ESL containing the given serial number
+ *@param esl_chain, pointer to chains of ESL buffer, esl's must contain x509s
+ *@param chain_size, length of esl_chain in bytes
+ *@param sn, pointer to serial number string, should be 20 bytes sperated by a colon, XX:...:XX
+ *@param ret_esl, a pointer to already allocarted memory to fill with the new ESL chain w/o the matching esl 
+ *@param ret_esl_size, size of the esl pointed to by ret_esl
+ *@return SUCCESS if an ESL with the serial number exists, else errno.
+ */
+static int remove_esl_with_serial(unsigned char *esl_chain, size_t chain_size, const char *sn, unsigned char **ret_esl, size_t *ret_esl_size)
+{
+    size_t remaining_esl_size, offset = 0, serial_len;
+    int rc, esl_data_size, itr_esl_size = 0, count = 1;
+    unsigned char *esl_data = NULL, sn_raw[20];
+    const unsigned char *itr_serial = NULL;
+    EFI_SIGNATURE_LIST *itr_esl;
+    crypto_x509 *x509 = NULL;
+    bool found_flag = false;
+
+    *ret_esl_size = 0;
+    // convert ascii serial number string to raw buffer
+    rc = convert_ascii_hex_to_raw_hex(sn, sn_raw, 20);
+    if (rc)
+    	return rc;
+    // loop through esl chain, if SN matches, don't add it
+    for (remaining_esl_size = chain_size; remaining_esl_size > 0; 
+        remaining_esl_size -= itr_esl_size, offset += itr_esl_size, count++) {
+        // get nex sig list size
+        itr_esl = get_esl_signature_list((char *)esl_chain + offset, remaining_esl_size);
+        if (itr_esl == NULL) {
+            prlog(PR_ERR, "Failed to parse ESL #%d\n", count);
+        }
+        itr_esl_size = itr_esl->SignatureListSize;
+        // buff to esl is basically type cast so this is our one sanity check
+        if (itr_esl_size > remaining_esl_size) {
+            prlog(PR_ERR, "ERROR: Expected size of ESL #%d is %d but only %lu bytes are available\n", count, itr_esl_size, remaining_esl_size);
+            break;
+        }
+        // get data from esl
+        esl_data_size = get_esl_cert((char *)esl_chain + offset, remaining_esl_size, (char **)&esl_data);
+        if (esl_data_size <= 0) {
+            prlog(PR_ERR, "\tERROR: Failed to extract certificate from ESL, no data\n");
+            break;
+        }
+        // get x509 from data
+        rc = parseX509(&x509, esl_data, (size_t)esl_data_size);
+        if (rc)
+            break;
+        // get serial number from x509
+        itr_serial = crypto_x509_get_serial_number(x509, &serial_len);
+        if (verbose >= PR_INFO) {
+        	prlog(PR_INFO,"Comparing serial against serial = ");
+        	printHex((unsigned char *)itr_serial, serial_len);
+        }
+        // compare
+        if (serial_len != 20) {
+        	prlog(PR_ERR, "ERROR: Serial number has length %zd, expected 20\n", serial_len);
+        	break;
+        }
+        //if not the ESL we want to remove,  add it to the new ESL
+        if (memcmp(itr_serial, sn_raw, serial_len) != 0) {
+        	memcpy(*ret_esl + *ret_esl_size, itr_esl, itr_esl_size);
+        	*ret_esl_size += itr_esl_size;
+        }
+        else {
+        	prlog(PR_INFO, "Found matching ESL. Removing now...\n");
+        	found_flag = true;
+        }
+        free(esl_data);
+        esl_data = NULL;
+    	crypto_x509_free(x509);
+    	x509 = NULL;
+    }
+
+    if (esl_data)
+    	free(esl_data);
+    if (x509)
+    	crypto_x509_free(x509);
+    
+    if (found_flag)
+    	return SUCCESS;
+
+    return ESL_FAIL;
+
+}
+// WHEERE NICK LEFT OFF, I THINK ITS WORKING KINDA. IF REMOVE THE ONLY ESL THEN RETURNED IS 0 BYTES DO THE RIGHT THING W THAT! 
+// I DIDNT GE TTO GENERATE NOTHIN SO TEST THAT
+
+/*
+ *called from main()
+ *handles argument parsing for remove command
+ *@param argc, number of argument
+ *@param arv, array of params
+ *@return SUCCESS or err number
+ */
+int performRemoveCommand(int argc, char *argv[])
+{
+	int rc;
+	size_t out_buff_size, curr_esl_size, updated_esl_size;
+	unsigned char *current_esl_buff = NULL, *updated_esl_buf = NULL, *out_buff = NULL;
+	struct Arguments args = { .help_flag = 0,
+				  .inp_valid = 0,
+				  .output_method = NO_SELECTION,
+				  .input_method = READ_FROM_SECVAR_PATH,
+				  .new_esl = NULL,
+				  .current_esl = NULL,
+				  .path_to_sec_vars = NULL,
+				  .serial_number = NULL,
+				  .auth_args = { .signKeyCount = 0,
+						 .signCertCount = 0,
+						 .signCerts = NULL,
+						 .signKeys = NULL,
+						 .varName = NULL,
+						 .time = NULL,
+						 .pkcs7_gen_meth = NO_PKCS7_GEN_METHOD } };
+	// combine command and subcommand for usage/help messages
+	argv[0] = "secvarctl remove";
+	struct argp_option options[] = {
+		{ "serialnum", 'x', "XX:XX...:XX", OPTION_NO_USAGE,
+		  "required serial number contained in X509 of ESL that is to be removed. "
+          "Must be 20 bytes, capitalized hex with each byte separated with ':'. Use "
+          "`secvarctl read` or `secvarctl validate -v -e` for correct SN format" },
+		{ 0 }
+	};
+
+	struct argp argp = {
+		options, remove_specific_parse_opt,
+		"-n <var_name> -k/-s <key/sig> -c <crt> -x <XX:XX..:XX> -o <out_file>\n-n <var_name> -k/-s <key/sig> -c <crt> -x <XX:XX..:XX> -w",
+		"This command removes an ESL from a current chain of ESL's and uses it to generate an valid Auth"
+		" file. The generated Auth can be output to a file with '-o' or submited as a secvar update with '-w'."
+		" The default location of secvars is " SECVARPATH ", use '-p' for other paths."
+		" At the moment only ESl's containing X509s can be removed. To see an x509 serial number contained in ESLs, see 'secvarctl read/validate --help'. ",
+		insert_remove_shared_child_parsers
+	};
+
+	rc = argp_parse(&argp, argc, argv, ARGP_NO_EXIT | ARGP_IN_ORDER | ARGP_NO_HELP, 0, &args);
+	if (rc || args.help_flag)
+		goto out;
+
+	/*fill in fields w/ default data*/
+
+	if (args.auth_args.time == NULL) {
+		args.auth_args.time = calloc(1, sizeof(*args.auth_args.time));
+		if (!args.auth_args.time) {
+			prlog(PR_ERR, "ERROR: failed to allocate memory\n");
+			rc = ALLOC_FAIL;
+			goto out;
+		}
+		rc = getTimestamp(args.auth_args.time);
+		if (rc)
+			goto out;
+	}
+	// if no custom path to secvars, use default
+	if (args.path_to_sec_vars == NULL)
+		args.path_to_sec_vars = SECVARPATH;
+
+	// generate helpful info string
+	prlog(PR_INFO, "Looking for ESL containing X509 with Serial Number %s in", args.serial_number);
+	if (args.input_method == READ_FROM_SECVAR_PATH)
+		prlog(PR_INFO, "%s%s/data", args.path_to_sec_vars, args.auth_args.varName);
+	else
+		prlog(PR_INFO, "%s", args.current_esl);
+	prlog(PR_INFO, ", will be output to ");
+	if (args.output_method == SUBMIT_AS_SECVAR_UPDATE)
+		prlog(PR_INFO, "%s%s/update\n", args.path_to_sec_vars, args.auth_args.varName);
+	else
+		prlog(PR_INFO, "%s\n", args.out_file);
+
+	//arg parsing, debug printing is done, now start process
+	// 1. get current esl from either getsecvar or read file
+	if (args.input_method == READ_FROM_SECVAR_PATH)
+		rc = getDataFromSecVar((char **)&current_esl_buff, &curr_esl_size,
+				       args.path_to_sec_vars, args.auth_args.varName);
+	else {
+		current_esl_buff =
+			(unsigned char *)getDataFromFile(args.current_esl, SIZE_MAX, &curr_esl_size);
+		if (current_esl_buff == NULL)
+			rc = INVALID_FILE;
+	}
+	if (rc) {
+		prlog(PR_ERR, "ERROR: Could not get current ESL\n");
+		goto out;
+	}
+	if (!args.inp_valid) {
+		prlog(PR_INFO, "Validating current ESL...\n");
+		rc = validateESL(current_esl_buff, curr_esl_size, args.auth_args.varName);
+		if (rc) {
+			prlog(PR_ERR, "ERROR: Could not validate current ESL\n");
+			goto out;
+		}
+	}
+
+    // max size of new esl is current esl
+    updated_esl_buf = malloc(curr_esl_size);
+    if (updated_esl_buf == NULL) {
+        prlog(PR_ERR, "ERROR: Failed to allocate memory\n");
+        goto out;
+    }
+    // 2. remove esl with serial number
+    rc = remove_esl_with_serial(current_esl_buff, curr_esl_size, args.serial_number, &updated_esl_buf, &updated_esl_size);
+    if (rc) {
+        prlog(PR_ERR, "ERROR: Could not find ESL with serial number %s in ESL chain\n", args.serial_number);
+        goto out;
+    }
+	if (args.inp_valid)
+		prlog(PR_INFO,
+		      "Generated ESL with %lu bytes, skipping validation ('-f' flag detected)\n",
+		      updated_esl_size);
+	else {
+		prlog(PR_INFO, "Validating updated ESL of %lu bytes...\n", updated_esl_size);
+		// empty ESL is valid but cannot be validated
+		if (updated_esl_size != 0) {
+			rc = validateESL(updated_esl_buf, updated_esl_size, args.auth_args.varName);
+			if (rc) {
+				prlog(PR_ERR,
+				      "ERROR: Failed to generate a valid ESL\n");
+				goto out;
+			}
+		}
+		prlog(PR_INFO, "Validating new  appended ESL successfull\n");
+	}
+	// 5. generate auth
+	rc = toAuth(updated_esl_buf, updated_esl_size, &(args.auth_args), 42, &out_buff,
+		    &out_buff_size);
+	if (rc) {
+		prlog(PR_ERR, "Failed to generate auth file with new appended ESL\n");
+		goto out;
+	}
+	prlog(PR_INFO, "Auth generation successful\n");
+	// 6. write file or write to secvars
+	if (args.output_method == SUBMIT_AS_SECVAR_UPDATE) {
+		prlog(PR_INFO, "Submitting secvar update...\n");
+		rc = updateVar(args.path_to_sec_vars, args.auth_args.varName, out_buff,
+			       out_buff_size);
+		if (rc)
+			prlog(PR_ERR, "Failed to submit as secvar update\n");
+	} else if (args.output_method == WRITE_TO_FILE) {
+		prlog(PR_INFO, "Writing to file %s...\n", args.out_file);
+		rc = createFile(args.out_file, (char *)out_buff, out_buff_size);
+		if (rc) {
+			prlog(PR_ERR, "ERROR: Could not write new data to output file %s\n",
+			      args.out_file);
+		}
+	}
+
+out:
+	if (out_buff)
+		free(out_buff);
+	if (current_esl_buff)
+		free(current_esl_buff);
+	if (updated_esl_buf)
+		free(updated_esl_buf);
+	if (args.auth_args.signKeys)
+		free(args.auth_args.signKeys);
+	if (args.auth_args.signCerts)
+		free(args.auth_args.signCerts);
+	if (args.auth_args.time)
+		free(args.auth_args.time);
+	if (!args.help_flag)
+		printf("RESULT: %s\n", rc ? "FAILURE" : "SUCCESS");
+
+	return rc;
+}
+
+/**
+ *@param key , every option that is parsed has a value to identify it
+ *@param arg, if key is an option than arg will hold its value ex: -<key> <arg>
+ *@param state,  argp_state struct that contains useful information about the current parsing state 
+ *@return success or errno
+ */
+static int remove_specific_parse_opt(int key, char *arg, struct argp_state *state)
+{
+    struct Arguments *args = state->input;
+    int rc = SUCCESS;
+
+    switch (key) {
+    case 'x':
+        args->serial_number = arg;
+        break;
+    case ARGP_KEY_INIT:
+        // for first loop around argp requires us to specify which data struct to use for child parsers
+        state->child_inputs[0] = args;
+        break;
+    case ARGP_KEY_SUCCESS:
+        // check that all essential args are given and valid
+        if (args->help_flag)
+            break;
+        // serial number must be 20 hex bytes, all caps, each byte seperated by ':' = 20*2 + 19
+        else if (args->serial_number == NULL)
+             prlog(PR_ERR, "ERROR: Missing serial number of ESL to remove, use '-x <XX:XX..:XX> `, see usage below...\n");
+        else if (strlen(args->serial_number) != 59)
+            prlog(PR_ERR, "ERROR: Input serial number format is invalid, needs 20 hex bytes seprated by ':' (59 chars total, found %lu)  see usage below...\n", strlen(args->serial_number));
+        else
+            break;
+        argp_usage(state);
+        rc = ARG_PARSE_FAIL;
+        break;
+    }
+
+    if (rc)
+        prlog(PR_ERR, "Failed during argument parsing\n");
+
+    return rc;
+}
+
 #endif

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -594,6 +594,7 @@ struct command edk2_compat_command_table[] = {
 	{ .name = "validate", .func = performValidation },
 	{ .name = "verify", .func = performVerificationCommand },
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
+	{ .name = "insert", .func = performInsertCommand },
 	{ .name = "generate", .func = performGenerateCommand }
 #endif
 };

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -595,6 +595,7 @@ struct command edk2_compat_command_table[] = {
 	{ .name = "verify", .func = performVerificationCommand },
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
 	{ .name = "insert", .func = performInsertCommand },
+	{ .name = "remove", .func = performRemoveCommand },
 	{ .name = "generate", .func = performGenerateCommand }
 #endif
 };

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -65,6 +65,7 @@ int performWriteCommand(int argc, char *argv[]);
 int performValidation(int argc, char *argv[]);
 int performGenerateCommand(int argc, char *argv[]);
 int performInsertCommand(int argc, char *argv[]);
+int performRemoveCommand(int argc, char *argv[]);
 
 int printCertInfo(crypto_x509 *x509);
 void printESLInfo(EFI_SIGNATURE_LIST *sigList);
@@ -109,6 +110,6 @@ struct Auth_specific_args {
 int toAuth(const unsigned char *newESL, size_t eslSize, struct Auth_specific_args *args,
 	   int hashFunct, unsigned char **outBuff, size_t *outBuffSize);
 
-extern struct command edk2_compat_command_table[6];
+extern struct command edk2_compat_command_table[7];
 
 #endif

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -64,6 +64,7 @@ int performVerificationCommand(int argc, char *argv[]);
 int performWriteCommand(int argc, char *argv[]);
 int performValidation(int argc, char *argv[]);
 int performGenerateCommand(int argc, char *argv[]);
+int performInsertCommand(int argc, char *argv[]);
 
 int printCertInfo(crypto_x509 *x509);
 void printESLInfo(EFI_SIGNATURE_LIST *sigList);
@@ -108,6 +109,6 @@ struct Auth_specific_args {
 int toAuth(const unsigned char *newESL, size_t eslSize, struct Auth_specific_args *args,
 	   int hashFunct, unsigned char **outBuff, size_t *outBuffSize);
 
-extern struct command edk2_compat_command_table[5];
+extern struct command edk2_compat_command_table[6];
 
 #endif

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -11,6 +11,7 @@
 #include "libstb/secvar/crypto/crypto.h"
 #include "external/skiboot/libstb/secvar/backend/edk2.h"
 #include "external/skiboot/libstb/secvar/backend/edk2-compat-process.h"
+#include "argp.h"
 
 // all argp options must have a single character option
 // so we set --usage to have a single character option that is out of range
@@ -84,4 +85,22 @@ int validateTS(const unsigned char *data, size_t size);
 int validateTime(struct efi_time *time);
 
 extern struct command edk2_compat_command_table[5];
+
+// below is for arg parsing for any type of generate signed data (auth/pkcs7) command
+extern struct argp gen_auth_specific_argp;
+enum pkcs7_generation_method {
+	// for -k <key> option
+	W_PRIVATE_KEYS = 0,
+	// for -s <sig> option
+	W_EXTERNAL_GEN_SIG,
+	// default, when not generating a pkcs7/auth
+	NO_PKCS7_GEN_METHOD
+};
+struct Auth_specific_args {
+	// the pkcs7_gen_meth is to determine if signKeys stores a private key file(0) or signed data (1)
+	int signKeyCount, signCertCount;
+	const char **signCerts, **signKeys, *varName;
+	struct efi_time *time;
+	enum pkcs7_generation_method pkcs7_gen_meth;
+};
 #endif

--- a/backends/edk2-compat/include/edk2-svc.h
+++ b/backends/edk2-compat/include/edk2-svc.h
@@ -76,6 +76,7 @@ const char *getSigType(const uuid_t);
 int getSecVar(struct secvar **var, const char *name, const char *fullPath);
 int updateVar(const char *path, const char *var, const unsigned char *buff, size_t size);
 int isVariable(const char *var);
+int getDataFromSecVar(char **out_data, size_t *size, const char *path, const char *variable);
 
 int validateAuth(const unsigned char *authBuf, size_t buflen, const char *key);
 int validateESL(const unsigned char *eslBuf, size_t buflen, const char *key);
@@ -84,7 +85,8 @@ int validatePKCS7(const unsigned char *cert_data, size_t len);
 int validateTS(const unsigned char *data, size_t size);
 int validateTime(struct efi_time *time);
 
-extern struct command edk2_compat_command_table[5];
+int getHashFunction(const char *name, struct hash_funct **returnFunct);
+int getTimestamp(struct efi_time *ts);
 
 // below is for arg parsing for any type of generate signed data (auth/pkcs7) command
 extern struct argp gen_auth_specific_argp;
@@ -103,4 +105,9 @@ struct Auth_specific_args {
 	struct efi_time *time;
 	enum pkcs7_generation_method pkcs7_gen_meth;
 };
+int toAuth(const unsigned char *newESL, size_t eslSize, struct Auth_specific_args *args,
+	   int hashFunct, unsigned char **outBuff, size_t *outBuffSize);
+
+extern struct command edk2_compat_command_table[5];
+
 #endif

--- a/external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
+++ b/external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
@@ -289,6 +289,11 @@ int crypto_x509_get_pk_bit_len(crypto_x509 *x509)
 	return mbedtls_pk_get_bitlen(&x509->pk);
 }
 
+const unsigned char *crypto_x509_get_serial_number(crypto_x509 *x509, size_t *serial_len)
+{
+	*serial_len = x509->serial.len;
+	return x509->serial.p;
+}
 void crypto_x509_get_short_info(crypto_x509 *x509, char *short_desc,
 				size_t max_len)
 {

--- a/external/skiboot/libstb/secvar/crypto/crypto-openssl.c
+++ b/external/skiboot/libstb/secvar/crypto/crypto-openssl.c
@@ -527,6 +527,15 @@ int crypto_x509_get_pk_bit_len(crypto_x509 *x509)
 	return length;
 }
 
+const unsigned char *crypto_x509_get_serial_number(crypto_x509 *x509, size_t *serial_len)
+{	
+
+ 	ASN1_INTEGER * sn;
+ 	sn = X509_get_serialNumber(x509);
+ 	*serial_len = (size_t)sn->length;
+	return sn->data;
+}
+
 void crypto_x509_get_short_info(crypto_x509 *x509, char *short_desc,
 				size_t max_len)
 {

--- a/external/skiboot/libstb/secvar/crypto/crypto.h
+++ b/external/skiboot/libstb/secvar/crypto/crypto.h
@@ -144,6 +144,14 @@ int crypto_x509_get_sig_len(crypto_x509 *x509);
 int crypto_x509_md_is_sha256(crypto_x509 *x509);
 int crypto_x509_oid_is_pkcs1_sha256(crypto_x509 *x509);
 int crypto_x509_get_pk_bit_len(crypto_x509 *x509);
+
+/*
+ *return a pointer to the internal serial number of an x509
+ *@param x509, a pointer to either an openssl or mbedtls x509 struct
+ *@param serial_len, the output length in bytes of the serial number
+ *@return a pointer to the serial number in the x509, DO NOT FREE
+ */
+const unsigned char *crypto_x509_get_serial_number(crypto_x509 *x509, size_t *serial_len);
 /*
  *checks the type of the x509 and ensures that it is of type RSA
  *@param x509, a pointer to either an openssl or mbedtls x509 struct

--- a/secvarctl.1
+++ b/secvarctl.1
@@ -1,4 +1,4 @@
-.TH secvarctl 1 "1 OCTOBER 2020" "version 0.1"
+.TH secvarctl 1 "28 MAY 2021" "version 0.3"
 .SH NAME
 .B secvarctl
 - A command line tool for simplifying the reading and writing of secure boot variables.
@@ -20,6 +20,9 @@ Commands are:
 .PP
 .B generate 
 - generates several different types of file formats relevant to updating secure variables
+.PP
+.B insert
+- add new key value to secure variable's current data
 .RE
 
 .SH SYNOPSIS
@@ -44,6 +47,9 @@ Commands are:
 .PP
 .B secvarctl generate reset 
 [OPTIONS] -o <outputFile> -k <key> -c <crt> -n <variable>
+.PP
+.B secvarctl insert
+[OPTIONS]  -n <var_name> -k/-s <key/sig> -c <crt> -i <new_esl> {-o <out_file> OR -w}
 
 .SH DESCRIPTION
 .B secvarctl
@@ -58,6 +64,8 @@ The purpose of this tool is to simplify and automate the process of reading, wri
 .B verify
 ,
 .B generate
+,
+.B insert
 )
 
 .RS
@@ -206,8 +214,27 @@ with
 This will generate an auth file around an empty ESL. Thus, no input argument 
 .B -i 
 is required when making a reset file. 
-  NOTE: GENERATION OF PKCS7 AND AUTH FILES ARE IN EXPERIMENTAL DEVELEPOMENT PHASE. THEY HAVE NOT BEEN THOROUGHLY TESTED YET.
-
+.PP
+.B secvarctl insert
+will add a new ESL to a secvars current list of ESLs. This is useful if the user would like to update a secvar without overwriting the previous value. Due to firmware limitations, all secvar updates will overwrite the previous value of the secvar. The only way to retain previous values, is to append the new value to the old value and create an auth file over the combined value. This auth file can either be ouput to a file with
+.B -o
+<outputFile> or submitted as a secvar update with
+.B -w
+By default, the current esl is read from the secvar path, but a user given ESL chain can be used with the 
+.B -e
+option. The secvar path that is used for reading the current ESL and writing the ouput auth (if 
+.B -w
+is present), can be set to a user defined path with 
+.B -p 
+<path>. If, the 
+.B -f
+flag is given, the new, current and combined ESL will not be checked for format correctness. Since an auth file is being generated, all required flags for auth generation from the 
+.B secvarctl generate
+command are needed, this includes 
+.B -k/-s, -c, -n
+The 
+.B -t
+<time> flag has also been used to allow the user to specify the timestamp to use in the auth file metadata.
 .RE
 
 .SH OPTIONS
@@ -406,6 +433,60 @@ format of <time> = 'YYYY-MM-DDThh:mm:ss' where:
 and generates an auth file with an empty ESL (a valid variable reset file), no input file required. Required arguments are output file, signer public and private key and variable name.
 .RE
 .RE
+.PP
+For 
+.B secvarctl insert
+-n <var_name> -k/-s <key/sig> -c <crt> -i <new_esl> {-o <out_file> OR -w}
+.RS
+REQUIRED:
+.RS
+.B -i
+<new_esl> , the esl to be appended to the current esl
+.PP
+.B -w
+, submit update by writing output to secvar `update` file
+.PP
+.B -o 
+<outputFile>, alternative to 
+.B -w
+, write output auth to file
+.PP
+.B -n
+<varName>, one of {"PK", "KEK, "db", "dbx", "TS"}
+.PP
+.B -c 
+<certFile> , see 
+.B secvarctl generate
+.PP
+.B -k 
+<privKey> OR
+.B -s 
+<sigFile>, see 
+.B secvarctl generate
+.RE
+OPTIONAL:
+.RS
+.B --usage
+.PP
+.B --help
+.PP
+.B -v
+, verbose
+.PP
+.B -t 
+<time> , see GENERATE for description
+.PP
+.B -f 
+, force, do not validate file formats
+.PP
+.B -e 
+<esl> , specify current ESL to append data to, default is <PATH>/<VARNAME>/data
+.PP
+.B -p 
+<path> , specify path to current secvars, default is 
+.I "/sys/firmware/secvar/vars/" 
+
+.RE
 .SH EXAMPLES
 
 To read all current variables in default path:
@@ -460,7 +541,9 @@ To create an auth file using an external signing framework for db update:
       $secvarctl generate c:x -n db -t 2021-1-1T1:1:1 -i file.crt -o file.hash
       <user sends file.hash to be signed by external entity, signature is now in file.sig>
       $secvarctl generate c:a -n db -t 2021-1-1T1:1:1 -c signer.crt -s file.sig -i file.crt -o file.auth 
-
+.PP
+To append add a new ESL entry to the current value of the db:
+      $secvarctl insert -i new.esl -k KEK.key -c KEK.crt -n db -w
 .SH AUTHOR
 Nick Child nick.child@ibm.com,
 .PP

--- a/secvarctl.1
+++ b/secvarctl.1
@@ -22,7 +22,10 @@ Commands are:
 - generates several different types of file formats relevant to updating secure variables
 .PP
 .B insert
-- add new key value to secure variable's current data
+- add new ESL to secure variable's current data
+.PP
+.B remove
+- remove an ESL from secure variable's current data 
 .RE
 
 .SH SYNOPSIS
@@ -50,6 +53,9 @@ Commands are:
 .PP
 .B secvarctl insert
 [OPTIONS]  -n <var_name> -k/-s <key/sig> -c <crt> -i <new_esl> {-o <out_file> OR -w}
+.PP
+.B secvarctl remove
+[OPTIONS] -n <var_name> -k/-s <key/sig> -c <crt> -x <serial_number> {-o <out_file> OR -w}
 
 .SH DESCRIPTION
 .B secvarctl
@@ -66,6 +72,8 @@ The purpose of this tool is to simplify and automate the process of reading, wri
 .B generate
 ,
 .B insert
+,
+.B remove
 )
 
 .RS
@@ -216,7 +224,7 @@ This will generate an auth file around an empty ESL. Thus, no input argument
 is required when making a reset file. 
 .PP
 .B secvarctl insert
-will add a new ESL to a secvars current list of ESLs. This is useful if the user would like to update a secvar without overwriting the previous value. Due to firmware limitations, all secvar updates will overwrite the previous value of the secvar. The only way to retain previous values, is to append the new value to the old value and create an auth file over the combined value. This auth file can either be ouput to a file with
+will add a new ESL to a secvars current list of ESLs. This is useful if the user would like to update a secvar without overwriting the previous value. Due to firmware limitations, all secvar updates will overwrite the previous value of the secvar. The only way to retain previous values, is to append the new value to the old value and create an auth file over the combined value. This auth file can either be output to a file with
 .B -o
 <outputFile> or submitted as a secvar update with
 .B -w
@@ -235,6 +243,35 @@ command are needed, this includes
 The 
 .B -t
 <time> flag has also been used to allow the user to specify the timestamp to use in the auth file metadata.
+.PP
+.B secvarctl remove
+will remove an ESL entry from a secvars current list of ESLs. This is useful if the user would like to delete only a portion of the secure variables data without completely removing it (for this use 
+.B secvarctl generate reset
+). This command is very similar to 
+.B secvarctl insert
+except instead of using the
+.B -i
+flag to recieve a new ESL, the 
+.B remove
+command uses
+.B -x
+<serial_number> to identify the ESL which is to be removed. All of the other arguments 
+.B -o, -w, -e, -p, -f, -k/s, -c, -k, -n, -t
+are identical to their use in 
+.B secvarctl insert
+command. The argument
+.B -x
+<serial_number> is required and must contain a valid 20 byte serial number that is contained in an X509 of one of the ESL's in the current secure variable. The format of this serial number must be in hexadecimal octets seperated by a ':' . To see the serial numbers in an ESL, either 
+.B secvarctl read
+or 
+.B secvarctl validate -v -e <esl_file>
+can be used. Since the dbx variable does not contain X509's, the
+.B -x <serial_number>
+argument can accept a hash instead. This hash must be one of the hashes being stored in one of the dbx's ESLs. The format of the argument is the same and finding available hashes to extract can be done with either the
+.B secvarctl read dbx
+or
+.B secvarctl validate -v -x -e <esl_file>
+commands.
 .RE
 
 .SH OPTIONS
@@ -452,7 +489,7 @@ REQUIRED:
 , write output auth to file
 .PP
 .B -n
-<varName>, one of {"PK", "KEK, "db", "dbx", "TS"}
+<varName>, one of {"PK", "KEK, "db", "dbx"}
 .PP
 .B -c 
 <certFile> , see 
@@ -477,7 +514,7 @@ OPTIONAL:
 <time> , see GENERATE for description
 .PP
 .B -f 
-, force, do not validate file formats
+, force, does not validate file formats
 .PP
 .B -e 
 <esl> , specify current ESL to append data to, default is <PATH>/<VARNAME>/data
@@ -485,7 +522,59 @@ OPTIONAL:
 .B -p 
 <path> , specify path to current secvars, default is 
 .I "/sys/firmware/secvar/vars/" 
-
+.RE
+.RE
+.PP
+.B secvarctl remove
+-n <var_name> -k/-s <key/sig> -c <crt> -x <serial_number> {-o <out_file> OR -w}
+.RS
+REQUIRED:
+.RS
+.B -x
+<serial_number> , the serial number in the X509 of the ESL to remove from the current esl. If variable being updated is dbx, then this is a hash instead of a serial number
+.PP
+.B -w
+, submit update by writing output to secvar `update` file
+.PP
+.B -o 
+<outputFile>, alternative to 
+.B -w
+, write output auth to file
+.PP
+.B -n
+<varName>, one of {"PK", "KEK, "db", "dbx"}
+.PP
+.B -c 
+<certFile> , see 
+.B secvarctl generate
+.PP
+.B -k 
+<privKey> OR
+.B -s 
+<sigFile>, see 
+.B secvarctl generate
+.RE
+OPTIONAL:
+.RS
+.B --usage
+.PP
+.B --help
+.PP
+.B -v
+, verbose
+.PP
+.B -t 
+<time> , see GENERATE for description
+.PP
+.B -f 
+, force, does not validate file formats
+.PP
+.B -e 
+<esl> , specify current ESL to remove data from, default is <PATH>/<VARNAME>/data
+.PP
+.B -p 
+<path> , specify path to current secvars, default is 
+.I "/sys/firmware/secvar/vars/"
 .RE
 .SH EXAMPLES
 
@@ -542,8 +631,11 @@ To create an auth file using an external signing framework for db update:
       <user sends file.hash to be signed by external entity, signature is now in file.sig>
       $secvarctl generate c:a -n db -t 2021-1-1T1:1:1 -c signer.crt -s file.sig -i file.crt -o file.auth 
 .PP
-To append add a new ESL entry to the current value of the db:
+Submit an update to append a new ESL entry to the current value of the db:
       $secvarctl insert -i new.esl -k KEK.key -c KEK.crt -n db -w
+.PP
+Submit an update to remove an ESL entry from the current KEK:
+      $secvarctl remove -k PK.key -c PK.crt -n KEK -w -x DE:AD:BE:EF:DE:AD:BE:EF:DE:AD:DE:AD:BE:EF:DE:AD:BE:EF:DE:AD
 .SH AUTHOR
 Nick Child nick.child@ibm.com,
 .PP

--- a/secvarctl.c
+++ b/secvarctl.c
@@ -29,6 +29,8 @@ void usage()
 	       "verify\t\tcompares proposed variable to the current variables,\n\t\t\t"
 	       "use 'secvarctl verify --usage/help' for more information\n"
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
+	       "\tinsert\t\tappends data to preexisting secure variable data\n\t\t\t"
+	       "use 'secvarctl insert --usage/help' for more information\n"
 	       "\tgenerate\tcreates relevant files for secure variable management,\n\t\t\t"
 	       "use 'secvarctl generate --usage/help' for more information\n"
 #endif

--- a/secvarctl.c
+++ b/secvarctl.c
@@ -31,6 +31,8 @@ void usage()
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
 	       "\tinsert\t\tappends data to preexisting secure variable data\n\t\t\t"
 	       "use 'secvarctl insert --usage/help' for more information\n"
+	       "\tremove\t\tremoves data entry from preexisting secure variable data\n\t\t\t"
+	       "use 'secvarctl remove --usage/help' for more information\n"
 	       "\tgenerate\tcreates relevant files for secure variable management,\n\t\t\t"
 	       "use 'secvarctl generate --usage/help' for more information\n"
 #endif

--- a/test/runSvcGenerateTests.py
+++ b/test/runSvcGenerateTests.py
@@ -555,7 +555,21 @@ class Test(unittest.TestCase):
 			#keep adding ESL's to KEK and checking with db updates
 
 		setupTestEnv()
-
+		#add test for appending to dbx
+		#make auth file with new dbx entry appended to current dbx
+		new_dbx=inpDir+"dbx_by_PK.esl"
+		self.assertEqual(getCmdResult(cmd + [ "-i", new_dbx, "-o", output_file] + required_path_args + ["-c", "testenv/PK/PK.crt", "-k", "testenv/PK/PK.key", "-n", "dbx"], out, self), True)
+		#run `secvarctl verify` to ensure it would be successful
+		self.assertEqual(getCmdResult([SECTOOLS, "verify", "-v"] + required_path_args + ["-u", "dbx", output_file], out, self), True)
+		#the contained ESL should equal dbx entry in sysfs appended with new ESL
+		self.assertEqual(getCmdResult([SECTOOLS, "generate", "a:e", "-i", output_file, "-o", output_file_esl, "-n", "dbx"], out, self), True)
+		dbx_expected ="generatedTestData/foo_expected.esl"
+		with open(dbx_expected, 'wb') as out_file:
+			for dbx_esl in ['testenv/dbx/data', new_dbx]:
+					with open(dbx_esl, 'rb') as in_file:
+						out_file.write(in_file.read())
+		self.assertEqual(compareFiles(output_file_esl, dbx_expected), True)
+		command(["rm", output_file, output_file_esl, dbx_expected])
 		#extra test for force flag
 		#appending and signing two empty files should fail since 0 + 0 is not an esl
 		self.assertEqual(getCmdResult(cmd + required_auth_args + ["-i", "./testdata/empty.esl", "-e", "testdata/empty.esl", "-o", "generatedTestData/empty_w_empy.auth"], out, self ), False)


### PR DESCRIPTION
In response to [Nageswara's recommendation](https://github.com/open-power/secvarctl/issues/10), this pull request adds a new secvarctl subcommand: insert. `secvarctl insert` allows for a new secvar update to be submitted without the old one being replaced. The use case is if the user would like to add an ESL without overwriting the previous secvar ESLs.  

This PR comes complete with implementations, tests and documentation for the new `secvarctl insert` command. 

Okay, so I sorta-kinda lied when I said "`secvarctl insert` allows for a new secvar update to be submitted without the old one being replaced" . In reality, the function gets the current ESLs and appends the new ESL to it. With the combined ESL, it is sent to be put into an auth file. With the auth file, `secvarctl insert` allows the user to use the `-w` flag to submit the update to secvar sysfs or to a file with `-o <outFile>`. So, to simplify, the function really takes in two ESL's-> appends them -> generate auth -> ouptut . Various flags were added for different use cases. For example, by default the current ESL is taken from secvar sysfs `/sys/firmware/secvar/vars/<varName>/data` but the user can use `-e <eslFile>` to specify the current ESL. Additionally, the `-p PATH` flag can be used to specify the sysfs where it writes (to `PATH/<varName>/update`) and reads (to `PATH/<varName>/data`

Special thanks to @nasastry for a great feature request! I promise `secvarctl remove` is coming soon... 