### PR TITLE
Do not install man pages into /usr/local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ OBJ +=$(SKIBOOT_OBJ) $(EDK2_OBJ)
 
 OBJCOV = $(patsubst %.o, %.cov.o,$(OBJ))
 
-MANDIR=usr/local/share/man
+MANDIR=usr/share/man
 #use STATIC=1 for static build
 STATIC = 0
 ifeq ($(STATIC),1)


### PR DESCRIPTION
the binary is installed into /usr/bin and the man page into
/usr/local/man. That does not make any sense.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>