### PR TITLE
add max_len feature to getDataFromFile

### DIFF
--- a/backends/edk2-compat/edk2-svc-generate.c
+++ b/backends/edk2-compat/edk2-svc-generate.c
@@ -193,7 +193,7 @@ int performGenerateCommand(int argc, char *argv[])
 		size = 0;
 	else {
 		// get data from input file
-		buff = (unsigned char *)getDataFromFile(args.inFile, &size);
+		buff = (unsigned char *)getDataFromFile(args.inFile, 0, &size);
 		if (buff == NULL) {
 			prlog(PR_ERR, "ERROR: Could not find data in file %s\n", args.inFile);
 			rc = INVALID_FILE;
@@ -529,9 +529,9 @@ static int generateAuthOrPKCS7(const unsigned char *buff, size_t size, struct Ar
 
 	if (rc) {
 		prlog(PR_ERR, "Failed to generate %s file, use `--help` for more info\n",
-		      args->outForm[0] == 'a' ? "Auth" :
-		      args->outForm[0] == 'x' ? "pre-signed hash" :
-						      "PKCS7");
+		      args->outForm[0] == 'a' ?
+			      "Auth" :
+			      args->outForm[0] == 'x' ? "pre-signed hash" : "PKCS7");
 		goto out;
 	}
 out:

--- a/backends/edk2-compat/edk2-svc-read.c
+++ b/backends/edk2-compat/edk2-svc-read.c
@@ -230,7 +230,7 @@ static int readFileFromPath(const char *file, int hrFlag)
 	int rc;
 	size_t size = 0;
 	char *c = NULL;
-	c = getDataFromFile(file, &size);
+	c = getDataFromFile(file, 0, &size);
 	if (!c) {
 		return INVALID_FILE;
 	}
@@ -258,11 +258,9 @@ static int readFileFromPath(const char *file, int hrFlag)
  */
 int getSecVar(struct secvar **var, const char *name, const char *fullPath)
 {
-	int rc, fptr;
-	size_t size;
-	ssize_t read_size;
+	int rc;
+	size_t size, out_size;
 	char *sizePath = NULL, *c = NULL;
-	struct stat fileInfo;
 	rc = isFile(fullPath);
 	if (rc) {
 		return rc;
@@ -290,46 +288,26 @@ int getSecVar(struct secvar **var, const char *name, const char *fullPath)
 
 	if (size == 0) {
 		prlog(PR_WARNING, "Secure Variable has size of zero, (specified by size file)\n");
-		/*rc = INVALID_FILE;
-		return rc;*/
+		out_size = size;
+		c = malloc(size);
+		if (!c) {
+			prlog(PR_ERR, "ERROR: failed to allocate memory\n");
+			return ALLOC_FAIL;
+		}
+	} else {
+		c = getDataFromFile(fullPath, size, &out_size);
+		if (!c)
+			return INVALID_FILE;
 	}
-
-	fptr = open(fullPath, O_RDONLY);
-	if (fptr < 0) {
-		prlog(PR_WARNING, "-----opening %s failed: %s-------\n\n", fullPath,
-		      strerror(errno));
-		return INVALID_FILE;
-	}
-	if (fstat(fptr, &fileInfo) < 0) {
-		return INVALID_FILE;
-	}
-	// if file size is less than expeced size, error
-	if (fileInfo.st_size < size) {
-		prlog(PR_ERR, "ERROR: expected size (%zd) is less than actual size (%ld)\n", size,
-		      fileInfo.st_size);
-		return INVALID_FILE;
-	}
-	prlog(PR_NOTICE, "---opening %s is success: reading %zd bytes---- \n", fullPath, size);
-	c = malloc(size);
-	if (!c) {
-		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
-		return ALLOC_FAIL;
-	}
-
-	read_size = read(fptr, c, size);
-	if (read_size != size) {
-		prlog(PR_ERR, "ERROR: did not read all data of %s in one go\n", fullPath);
+	if (size != out_size) {
+		prlog(PR_ERR,
+		      "ERROR: expected size of secvar (%zd) is not equal to actual size (%zd)\n",
+		      size, out_size);
 		free(c);
-		close(fptr);
-		return INVALID_FILE;
-	}
-	close(fptr);
-	if (!c) {
-		prlog(PR_ERR, "ERROR: no data in file");
 		return INVALID_FILE;
 	}
 
-	*var = new_secvar(name, strlen(name) + 1, c, size, 0);
+	*var = new_secvar(name, strlen(name) + 1, c, out_size, 0);
 	if (*var == NULL) {
 		prlog(PR_ERR, "ERROR: Could not convert data to secvar\n");
 		free(c);

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -64,7 +64,7 @@ int performValidation(int argc, char *argv[])
 	if (rc || args.helpFlag)
 		goto out;
 
-	buff = (unsigned char *)getDataFromFile(args.inFile, &size);
+	buff = (unsigned char *)getDataFromFile(args.inFile, 0, &size);
 	if (!buff) {
 		prlog(PR_ERR, "ERROR: failed to get data from %s\n", args.inFile);
 		rc = INVALID_FILE;

--- a/backends/edk2-compat/edk2-svc-verify.c
+++ b/backends/edk2-compat/edk2-svc-verify.c
@@ -326,7 +326,7 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 	// once here, strings should be ready, it is time to fill banks
 	// fill update bank with all updates
 	for (int i = 0; i < updateCount; i += 2) {
-		c = getDataFromFile((char *)updateVars[i + 1], &len);
+		c = getDataFromFile((char *)updateVars[i + 1], 0, &len);
 		if (c) {
 			list_add_tail(update_bank, &new_secvar(updateVars[i],
 							       strlen(updateVars[i]) + 1, c, len, 0)
@@ -344,7 +344,7 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 				list_add_tail(variable_bank, &tmp->link);
 
 		} else {
-			c = getDataFromFile((char *)currentVars[i + 1], &len);
+			c = getDataFromFile((char *)currentVars[i + 1], 0, &len);
 			if (c) {
 				list_add_tail(variable_bank,
 					      &new_secvar(currentVars[i],

--- a/backends/edk2-compat/edk2-svc-write.c
+++ b/backends/edk2-compat/edk2-svc-write.c
@@ -162,7 +162,7 @@ static int updateSecVar(const char *varName, const char *authFile, const char *p
 	}
 
 	// get data to write, if force flag then validate the data is an auth file
-	buff = (unsigned char *)getDataFromFile(authFile, &size);
+	buff = (unsigned char *)getDataFromFile(authFile, 0, &size);
 	// if we are validating and validating fails, quit
 	if (!force) {
 		rc = validateAuth(buff, size, varName);

--- a/external/extraMbedtls/generate-pkcs7.c
+++ b/external/extraMbedtls/generate-pkcs7.c
@@ -609,7 +609,7 @@ static int toPKCS7(unsigned char **pkcs7, size_t *pkcs7Size, const char** crtFil
 	}
 	for (int i = 0; i < keyPairs; i++) {
 		// get data from public keys
-		crtPEM = (unsigned char *)getDataFromFile(crtFiles[i], &crtSizePEM);
+		crtPEM = (unsigned char *)getDataFromFile(crtFiles[i], 0, &crtSizePEM);
 		if (!crtPEM) {
 			prlog(PR_ERR, "ERROR: failed to get data from pub key file %s\n", crtFiles[i]);
 			rc = INVALID_FILE;
@@ -721,7 +721,7 @@ int to_pkcs7_generate_signature(unsigned char **pkcs7, size_t *pkcs7Size, const 
 
 	for (int i = 0; i < keyPairs; i++) {
 		// get data of private keys
-		keyPEM = (unsigned char *)getDataFromFile(keyFiles[i], &keySizePEM);
+		keyPEM = (unsigned char *)getDataFromFile(keyFiles[i], 0, &keySizePEM);
 
 		if (!keyPEM) {
 			prlog(PR_ERR, "ERROR: failed to get data from priv key file %s\n", keyFiles[i]);
@@ -797,7 +797,7 @@ int to_pkcs7_already_signed_data(unsigned char **pkcs7, size_t *pkcs7Size, const
 
 	for (int i = 0; i < keyPairs; i++) {
 		// get data from signature files
-		sigs[i] = getDataFromFile(sigFiles[i], &sig_sizes[i]);
+		sigs[i] = getDataFromFile(sigFiles[i], 0, &sig_sizes[i]);
 
 		if (!sigs[i]) {
 			prlog(PR_ERR, "ERROR: failed to get data from signature file %s\n", sigFiles[i]);

--- a/external/skiboot/libstb/secvar/crypto/crypto-openssl.c
+++ b/external/skiboot/libstb/secvar/crypto/crypto-openssl.c
@@ -253,7 +253,7 @@ int crypto_pkcs7_generate_w_signature(unsigned char **pkcs7, size_t *pkcs7Size,
 	//for every key pair get the data and add the signer to the pkcs7
 	for (int i = 0; i < keyPairs; i++) {
 		// get data of private keys
-		keyPEM = (unsigned char *)getDataFromFile(keyFiles[i],
+		keyPEM = (unsigned char *)getDataFromFile(keyFiles[i], 0,
 							  &keySizePEM);
 		if (!keyPEM) {
 			prlog(PR_ERR,
@@ -271,7 +271,7 @@ int crypto_pkcs7_generate_w_signature(unsigned char **pkcs7, size_t *pkcs7Size,
 			goto out;
 		}
 		//get data from crt
-		crtPEM = (unsigned char *)getDataFromFile(crtFiles[i],
+		crtPEM = (unsigned char *)getDataFromFile(crtFiles[i], 0,
 							  &crtSizePEM);
 		if (!keyPEM) {
 			prlog(PR_ERR,

--- a/generic.c
+++ b/generic.c
@@ -60,12 +60,13 @@ void printRaw(const char *c, size_t size)
 /**
  *This Function returns a pointer to allocated memory that holds the data from the file 
  *@param fullPath string of file with path
+ *@param max number of bytes to read or zero for read entire file
  *@param size address of unitialized int memory that will be filled with length of returned char*
  *@return NULL if cannot open file or read file
- *@return char* to allocted data of file with one extra '\0' for good measure
+ *@return char* to allocted data of file
  *NOTE:REMEMBER TO UNALLOCATE RETURNED DATA
  **/
-char *getDataFromFile(const char *fullPath, size_t *size)
+char *getDataFromFile(const char *fullPath, size_t max_bytes, size_t *size)
 {
 	int fptr;
 	char *c = NULL;
@@ -82,21 +83,26 @@ char *getDataFromFile(const char *fullPath, size_t *size)
 	if (fileInfo.st_size <= 0) {
 		prlog(PR_WARNING, "WARNING: file %s is empty\n", fullPath);
 	}
-	prlog(PR_NOTICE, "----opening %s is success: reading %ld bytes----\n", fullPath,
-	      fileInfo.st_size);
-	c = malloc(fileInfo.st_size);
+
+	if (max_bytes == 0)
+		max_bytes = fileInfo.st_size;
+	else if (max_bytes > fileInfo.st_size)
+		max_bytes = fileInfo.st_size;
+
+	prlog(PR_NOTICE, "----opening %s is success: reading %ld bytes----\n", fullPath, max_bytes);
+	c = malloc(max_bytes);
 	if (!c) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 		goto out;
 	}
-	read_size = read(fptr, c, fileInfo.st_size);
-	if (read_size != fileInfo.st_size) {
+	read_size = read(fptr, c, max_bytes);
+	if (read_size != max_bytes) {
 		prlog(PR_ERR, "ERROR: failed to read whole contents of %s in one go\n", fullPath);
 		free(c);
 		c = NULL;
 		goto out;
 	}
-	*size = fileInfo.st_size;
+	*size = max_bytes;
 out:
 	close(fptr);
 

--- a/include/generic.h
+++ b/include/generic.h
@@ -8,7 +8,7 @@ struct command {
 	int (*func)(int, char **);
 };
 
-char *getDataFromFile(const char *file, size_t *size);
+char *getDataFromFile(const char *file, size_t max_size, size_t *size);
 int writeData(const char *file, const char *buff, size_t size);
 int createFile(const char *file, const char *buff, size_t size);
 void printRaw(const char *c, size_t size);


### PR DESCRIPTION
This PR was in response to #25 . The issue was that we were trying to read all of a large file, when we only needed the first couple bytes. This issue is actually not unusual when reading secure variable files. In fact, when reading secvars we only read the amount of data specified in `<secvar>/size` since `<secvar>/data` is usually a much larger file than the data it contains. Since file reading processes have already been implemented in a couple different places and patterns are starting to grow, I decided to edit the function `getDataFromFile` (we really should switch to snake case sometime soon) to accept a parameter `max_len` so it only reads a max number of bytes. If the calling function wishes to read the entire file, they can use `max_len = 0`. This allowed me to go back to `getSecvar` and use the updated `getDataFromFile` call instead of re-implementing file read logic. 

Thanks to @nasastry for finding this issue.