### PR TITLE
BUG: edk2-compat.c: Turn on setup mode if PK is updated

### DIFF
--- a/external/skiboot/libstb/secvar/backend/edk2-compat.c
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat.c
@@ -207,14 +207,14 @@ static int edk2_compat_process(struct list_head *variable_bank,
 			 * hw-key-hash of that firmware. When PK is updated, hw-key-hash
 			 * is updated. And when PK is deleted, delete hw-key-hash as well
 			 */
-			/*if(neweslsize == 0) { //NICK REMOVED BECAUSE NO HW KEYS
+			if(neweslsize == 0) {
 				setup_mode = true;
-				delete_hw_key_hash(&staging_bank);
+				// delete_hw_key_hash(&staging_bank); //NICK REMOVED BECAUSE NO HW KEYS
 			} else  {
 				setup_mode = false;
-				add_hw_key_hash(&staging_bank);
+				// add_hw_key_hash(&staging_bank);
 			}
-			prlog(PR_DEBUG, "setup mode is %d\n", setup_mode);*/
+			prlog(PR_DEBUG, "setup mode is %d\n", setup_mode);
 		}
 	}
 

--- a/test/runTests.py
+++ b/test/runTests.py
@@ -74,11 +74,9 @@ verifyCommands=[
 [["-c", "PK","./testenv/PK/data", "./testenv/KEK/data", "KEK", "-u", "db","./testdata/db_by_PK.auth"], False],#current vars bad format 
 [["-c", "PK", "KEK", "./testenv/PK/data", "./testenv/KEK/data", "-u", "db","./testdata/db_by_PK.auth"], False],#current vars bad format 
 [["-c", "PK", "./testenv/PK/data", "KEK", "-u", "db","./testdata/db_by_PK.auth"], False],#current vars bad format 
-
-
-
-
+[["-c", "KEK", "./testenv/KEK/data", "-u", "PK", "./testdata/PK_by_PK.auth", "db", "./testdata/bad_db_by_db.auth"], False]
 ]
+
 writeCommands=[
 [["--usage"], True],[["--help"], True],
 [["KEK","./testdata/KEK_by_PK.auth", "-p", "./testenv/"], True], #different ordering should still work


### PR DESCRIPTION
Previously, we are commmenting out the section of code that enforced secure boot if the the PK is updated. I likely thought it was HW key related so I commented it out. I uncommented so now secure boot will be enforced as soon as a PK is enrolled.

This needs a test case but is a bug so opening the PR now.
