### PR TITLE
Allow for static builds to work again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,8 +56,13 @@ list ( APPEND SRC ${CRYPTOSRC} )
 option( STATIC "Create statically linked executable" OFF )
 if ( STATIC )
   set( BUILD_SHARED_LIBRARIES OFF )
+  #append possible extensions for library
+  set( CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   set( CMAKE_EXE_LINKER_FLAGS "-static" )
   set( PTHREAD "pthread" )
+else( )
+  #append possible extensions for library
+  LIST( APPEND CMAKE_FIND_LIBRARY_SUFFIXES ".so.0" )
 endif(  )
 
 #Strip resulting executable for minimal size
@@ -75,9 +80,6 @@ option( NO_CRYPTO "Build without crypto functions for smaller executable, some f
 if ( NO_CRYPTO )
   target_compile_definitions( secvarctl PRIVATE  NO_CRYPTO )
 endif(  )
-
-#append possible extensions for library
-LIST( APPEND CMAKE_FIND_LIBRARY_SUFFIXES ".so.0" ".a" ".so" )
 
 #if compiling with openssl, get libraries
 if (OPENSSL)

--- a/Makefile
+++ b/Makefile
@@ -26,14 +26,6 @@ OBJ +=$(SKIBOOT_OBJ) $(EDK2_OBJ)
 OBJCOV = $(patsubst %.o, %.cov.o,$(OBJ))
 
 MANDIR=usr/share/man
-#use STATIC=1 for static build
-STATIC = 0
-ifeq ($(STATIC),1)
-	STATICFLAG=-static
-	_LDFLAGS +=-lpthread
-else 
-	STATICFLAG=
-endif
 
 #use NO_CRYPTO for smaller executable but limited functionality
 NO_CRYPTO = 0 
@@ -61,6 +53,15 @@ else
 endif
 
 OBJ += $(CRYPTO_OBJ)
+
+#use STATIC=1 for static build
+STATIC = 0
+ifeq ($(STATIC),1)
+	STATICFLAG=-static
+	_LDFLAGS += -pthread -lpthread -ldl
+else
+	STATICFLAG=
+endif
 
 secvarctl: $(OBJ) 
 	$(CC) $(CFLAGS) $(_CFLAGS) $(STATICFLAG) $^  -o $@ $(LDFLAGS) $(_LDFLAGS)


### PR DESCRIPTION
Not sure when or why but static builds have stopped working in both Cmake and Make builds. `Makefile` needed some more linked libraries and rearrangement of the linking flags. `CMakeLists.txt` was matching with the shared libraries (`.so`) before matching with the `.a` libs. I believe I got everything working with mbedtls builds but openssl is segfaulting at runtime when building statically. It could be an issue with my specific `libopenssl.a` but I will look into it later on. For now, we need to allow for Cmake static mbedtls builds to run smoothly in order to continue with op-build work.
