### PR TITLE
Unify crypto return values

### DIFF
--- a/backends/edk2-compat/edk2-svc-generate.c
+++ b/backends/edk2-compat/edk2-svc-generate.c
@@ -564,7 +564,7 @@ static int generateESL(const unsigned char *buff, size_t size, struct Arguments 
 	case 'f':
 		rc = crypto_md_generate_hash(buff, size, hashFunct->crypto_md_funct,
 					     &intermediateBuff, &intermediateBuffSize);
-		if (rc) {
+		if (rc != CRYPTO_SUCCESS) {
 			prlog(PR_ERR, "Failed to generate hash from file\n");
 			break;
 		}
@@ -589,7 +589,7 @@ static int generateESL(const unsigned char *buff, size_t size, struct Arguments 
 		rc = crypto_convert_pem_to_der(*inpPtr, inpSize,
 					       (unsigned char **)&intermediateBuff,
 					       &intermediateBuffSize);
-		if (rc) {
+		if (rc != CRYPTO_SUCCESS) {
 			prlog(PR_ERR, "ERROR: Could not convert PEM to DER\n");
 			break;
 		}
@@ -687,7 +687,7 @@ static int generateHash(const unsigned char *data, size_t size, struct Arguments
 		}
 	}
 	rc = crypto_md_generate_hash(data, size, alg->crypto_md_funct, outHash, outHashSize);
-	if (rc) {
+	if (rc != CRYPTO_SUCCESS) {
 		prlog(PR_ERR, "Failed to generate hash\n");
 		return rc;
 	}
@@ -897,7 +897,7 @@ static int toHashForSecVarSigning(const unsigned char *ESL, size_t ESL_size, str
 		goto out;
 	}
 	rc = crypto_md_generate_hash(preHash, preHash_size, CRYPTO_MD_SHA256, outBuff, outBuffSize);
-	if (rc) {
+	if (rc != CRYPTO_SUCCESS) {
 		prlog(PR_ERR, "Failed to generate hash\n");
 		goto out;
 	}
@@ -1039,7 +1039,7 @@ static int toPKCS7ForSecVar(const unsigned char *newData, size_t dataSize, struc
 						       actualData, totalSize, args->signCerts,
 						       args->signKeys, args->signKeyCount,
 						       CRYPTO_MD_SHA256);
-	if (rc) {
+	if (rc != CRYPTO_SUCCESS) {
 		prlog(PR_ERR, "ERROR: making PKCS7 failed\n");
 		rc = PKCS7_FAIL;
 		goto out;

--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -521,14 +521,10 @@ static int validateCertStruct(crypto_x509 *x509, const char *varName)
 	}
 	// if public key type is not RSA, then quit (example failures: DSA, ECDSA, RSA_PCC)
 	rc = crypto_x509_is_RSA(x509);
-	if (rc) {
-		// openssl implementation for crypto_x509_is_RSA could return secvarctl's CERT_FAL no type found
-		if (rc == CERT_FAIL)
-			prlog(PR_ERR, "ERROR: public key type not able to be parsed from x509\n");
-		else
-			prlog(PR_ERR,
-			      "ERROR: public key type not supported, expected RSA, found type ID %d (defined by crypto lib)\n",
-			      rc);
+	if (rc != CRYPTO_SUCCESS) {
+		prlog(PR_ERR,
+		      "ERROR: public key type not supported, expected RSA, found type ID %d (defined by crypto lib)\n",
+		      rc);
 		return CERT_FAIL;
 	}
 

--- a/external/skiboot/libstb/secvar/backend/edk2-compat-process.c
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat-process.c
@@ -587,7 +587,7 @@ static int verify_signature(const struct efi_variable_authentication_2 *auth,
 		// rc = mbedtls_pkcs7_signed_hash_verify(pkcs7, &x509, (unsigned char *)newcert, new_data_size);
 		rc = crypto_pkcs7_signed_hash_verify(pkcs7, x509, (unsigned char *)newcert, new_data_size);
 		/* If you find a signing certificate, you are done */
-		if (rc == 0) {
+		if (rc == CRYPTO_SUCCESS) {
 			prlog(PR_INFO, "Signature Verification passed\n");
 			//NICK CHILD removed direct mbedtls call, use general crypto
 			// mbedtls_x509_crt_free(&x509);
@@ -664,7 +664,7 @@ static char *get_hash_to_verify(const char *key, const char *new_data,
 	// rc = mbedtls_md_starts(&ctx);
 	rc = crypto_md_ctx_init(&ctx, CRYPTO_MD_SHA256);
 
-	if (rc)
+	if (rc != CRYPTO_SUCCESS)
 		goto out;
 
 	if (key_equals(key, "PK")
@@ -685,20 +685,20 @@ static char *get_hash_to_verify(const char *key, const char *new_data,
 	rc = crypto_md_update(ctx, (const unsigned char *)wkey, varlen);
 
 	free(wkey);
-	if (rc) 
+	if (rc != CRYPTO_SUCCESS)
 		goto out;
 
 	//NICK CHILD removed direct mbedtls call, use general crypt
 	//rc = mbedtls_md_update(&ctx, (const unsigned char *)&guid, sizeof(guid));
 	rc = crypto_md_update(ctx, (const unsigned char *)&guid, sizeof(guid));
 
-	if (rc)
+	if (rc != CRYPTO_SUCCESS)
 		goto out;
 	//NICK CHILD removed direct mbedtls call, use general crypt
 	//rc = mbedtls_md_update(&ctx, (const unsigned char *)&attr, sizeof(attr));
 	rc = crypto_md_update(ctx, (const unsigned char *)&attr, sizeof(attr));
 
-	if (rc)
+	if (rc != CRYPTO_SUCCESS)
 		goto out;
 
 	//NICK CHILD removed direct mbedtls call, use general crypt
@@ -707,14 +707,14 @@ static char *get_hash_to_verify(const char *key, const char *new_data,
 	rc = crypto_md_update(ctx, (const unsigned char *)timestamp,
 			       sizeof(struct efi_time));
 
-	if (rc)
+	if (rc != CRYPTO_SUCCESS)
 		goto out;
 
 	//NICK CHILD removed direct mbedtls call, use general crypt	
 	// rc = mbedtls_md_update(&ctx, (const unsigned char *)new_data, new_data_size);
 	rc = crypto_md_update(ctx, (const unsigned char *)new_data, new_data_size);
 
-	if (rc)
+	if (rc != CRYPTO_SUCCESS)
 		goto out;
 
 	hash = zalloc(32);
@@ -724,7 +724,7 @@ static char *get_hash_to_verify(const char *key, const char *new_data,
 	//rc = mbedtls_md_finish(&ctx, hash);
 	rc = crypto_md_finish(ctx, hash);
 
-	if (rc) {
+	if (rc != CRYPTO_SUCCESS) {
 		free(hash);
 		hash = NULL;
 	}

--- a/external/skiboot/libstb/secvar/crypto/crypto.h
+++ b/external/skiboot/libstb/secvar/crypto/crypto.h
@@ -24,10 +24,12 @@ typedef EVP_MD_CTX crypto_md_ctx;
 #elif defined SECVAR_CRYPTO_MBEDTLS
 
 #include <mbedtls/md.h>
+#include <mbedtls/platform.h>
 // NICK CHILD was here
 //#include "libstb/crypto/pkcs7/pkcs7.h"
 #include "external/extraMbedtls/include/pkcs7.h"
 
+#define MBEDTLS_SUCCESS MBEDTLS_EXIT_SUCCESS
 #define CRYPTO_MD_SHA1 MBEDTLS_MD_SHA1
 #define CRYPTO_MD_SHA224 MBEDTLS_MD_SHA224
 #define CRYPTO_MD_SHA256 MBEDTLS_MD_SHA256

--- a/external/skiboot/libstb/secvar/crypto/crypto.h
+++ b/external/skiboot/libstb/secvar/crypto/crypto.h
@@ -10,6 +10,7 @@
 #include <openssl/x509.h>
 #include <openssl/evp.h>
 
+#define OPENSSL_SUCCESS 0
 #define CRYPTO_MD_SHA1 NID_sha1
 #define CRYPTO_MD_SHA224 NID_sha224
 #define CRYPTO_MD_SHA256 NID_sha256

--- a/external/skiboot/libstb/secvar/crypto/crypto.h
+++ b/external/skiboot/libstb/secvar/crypto/crypto.h
@@ -45,6 +45,7 @@ typedef mbedtls_md_context_t crypto_md_ctx;
 #include <gnutls/gnutls.h>
 #include <gnutls/pkcs7.h>
 
+#define GNUTLS_SUCCESS GNUTLS_E_SUCCESS
 #define CRYPTO_MD_SHA1 GNUTLS_DIG_SHA1
 #define CRYPTO_MD_SHA224 GNUTLS_DIG_SHA224
 #define CRYPTO_MD_SHA256 GNUTLS_DIG_SHA256

--- a/external/skiboot/libstb/secvar/crypto/crypto.h
+++ b/external/skiboot/libstb/secvar/crypto/crypto.h
@@ -11,6 +11,8 @@
 #include <openssl/evp.h>
 
 #define OPENSSL_SUCCESS 0
+#define CRYPTO_SUCCESS OPENSSL_SUCCESS
+
 #define CRYPTO_MD_SHA1 NID_sha1
 #define CRYPTO_MD_SHA224 NID_sha224
 #define CRYPTO_MD_SHA256 NID_sha256
@@ -30,6 +32,8 @@ typedef EVP_MD_CTX crypto_md_ctx;
 #include "external/extraMbedtls/include/pkcs7.h"
 
 #define MBEDTLS_SUCCESS MBEDTLS_EXIT_SUCCESS
+#define CRYPTO_SUCCESS MBEDTLS_SUCCESS
+
 #define CRYPTO_MD_SHA1 MBEDTLS_MD_SHA1
 #define CRYPTO_MD_SHA224 MBEDTLS_MD_SHA224
 #define CRYPTO_MD_SHA256 MBEDTLS_MD_SHA256
@@ -46,6 +50,8 @@ typedef mbedtls_md_context_t crypto_md_ctx;
 #include <gnutls/pkcs7.h>
 
 #define GNUTLS_SUCCESS GNUTLS_E_SUCCESS
+#define CRYPTO_SUCCESS GNUTLS_SUCCESS
+
 #define CRYPTO_MD_SHA1 GNUTLS_DIG_SHA1
 #define CRYPTO_MD_SHA224 GNUTLS_DIG_SHA224
 #define CRYPTO_MD_SHA256 GNUTLS_DIG_SHA256


### PR DESCRIPTION
This pull request is dependent on #33 

This pull request is a result of conversation from #30 .

Previously, both secvarctl and openssl/mbedtls/gnutls error codes were being returned from the crypto abstraction functions.
This PR will only return openssl/mbedtls/gnutls error codes.

Additionally, the calling functions were changed to expect `CRYPTO_SUCCESS` if the crypto abstraction function executed without errors. This allows us to set `CRYPTO_SUCCESS` to something specific to the imported library (it just so happens to be zero for mbedtls, gnutls and openssl) rather than always returning a secvarctl defined success value.