### PR TITLE
Add github actions for CI testing and building rpm's

### DIFF
--- a/.github/workflows/CI_formatting.yml
+++ b/.github/workflows/CI_formatting.yml
@@ -1,0 +1,21 @@
+name: Test Source Code Formatting
+
+on: ['push']
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+  
+    - name: install clang format
+      run: sudo apt install clang-format
+
+    - name: test if formatting is appropriate
+      run: |
+           make format
+           git status
+           git diff
+           [[ -z $(git status -s) ]]

--- a/.github/workflows/build_rpm.yml
+++ b/.github/workflows/build_rpm.yml
@@ -1,0 +1,164 @@
+name: Build RPMs on a new release
+
+on:
+  release:
+  workflow_dispatch:
+  
+# env:
+#     repo_url: ${{github.server_url}}/${{github.repository}}/archive/${{github.ref}}.tar.gz
+#     version: ${{ github.event.release.tag_name }}
+#     archive_file: ${version}.tar.gz
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    #run in a fedora container so we can use rpmbuild
+    container:
+      image: fedora
+      env:
+        repo_url: ${{github.server_url}}/${{github.repository}}/archive/${{github.ref}}.tar.gz
+        version: ${{ github.event.release.tag_name }}
+
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: install rpm tools cpio and wget
+        run:  sudo dnf install -y rpm-build cpio wget
+      - name: get src.rpm from old SUSE release
+        run:  wget https://download.opensuse.org/repositories/home:/nchild/openSUSE_Tumbleweed/src/secvarctl-0.3-7.1.src.rpm
+      - name: print env variables
+        run: env
+      - name: extract spec file from source rpm
+        run: |
+             rpm2cpio secvarctl-0.3-7.1.src.rpm | cpio -i
+             rm v0.3.tar.gz
+             ls secvarctl.spec
+#       - name: Get the version
+#         id: get_version
+#         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+      
+      - name: get release archives
+        run: |
+             wget ${repo_url}
+      - name: set version env var depending on version
+        run: |
+             echo "version=${version}" >> $GITHUB_ENV
+             echo $GITHUB_ENV
+            
+      - name: set archive file name for no version
+        if: ${{env.version == ''}}
+        run: echo "archive_file=main.tar.gz" >> $GITHUB_ENV
+      - name: set archive file name
+        if: ${{env.version != ''}}
+        run: echo "archive_file=${version}.tar.gz" >> $GITHUB_ENV
+#       - name: check files are present
+#         if: env.version == ''
+#         run: ls main.tar.gz
+      - name: check version files are present
+#         if: env.version != ''
+        run: |
+             echo looking for ${archive_file}
+             ls ${archive_file}
+      
+      #set version in spec file to version (minus any 'v's)
+      - name: configure spec file for specific version
+        if: env.version != ''
+        run: sed -i s/0.3/`echo $version | sed -n 's/[v]*\([^ ]*\)/\1/p'`/g secvarctl.spec
+      - name: configure spec file for non version build
+        if: env.version == ''
+        run: sed -i s/0.3/main/g secvarctl.spec
+      - name: set release value in spec file to 0
+        run: sed -i s/7.1/0/ secvarctl.spec
+      - name: configure spec file to ignore man file format
+        run: sed -i s/%{?ext_man}/\*/ secvarctl.spec 
+        
+      - name: show spec file
+        run: cat secvarctl.spec
+      - name: setup buildroot
+      #rpmbuild expects specfile and v<specfile version>.tar.gz
+        run: |
+             mkdir ~/rpmbuild
+             mkdir ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+             cp secvarctl.spec ~/rpmbuild/SPECS/
+             cp ${archive_file} ~/rpmbuild/SOURCES/v`sed -n 's/.*Version:\s*\([^ ]*\).*/\1/p' secvarctl.spec`.tar.gz
+       # install package dpeendencies
+      - name: install package dependencies
+        run: sudo dnf install -y cmake gcc openssl-devel
+      - name: build rpms
+        run: |
+             cd ~/rpmbuild
+             rpmbuild -ba SPECS/secvarctl.spec
+             ls -la SRPMS/
+             ls -la RPMS/x86_64/
+             echo "x86_rpm=`ls -d ~/rpmbuild/RPMS/x86_64/* | head -1`" >> $GITHUB_ENV
+             echo "srpm=`ls -d ~/rpmbuild/SRPMS/* | head -1`" >> $GITHUB_ENV
+             
+             
+      # upload artifacts to github action
+      - name: upload rpm's to github action artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: secvarctl-${{env.version}}.x86_64.rpm
+          path: ${{env.x86_rpm}}
+      - uses: actions/upload-artifact@v2
+        with:
+          name: secvarctl-${{env.version}}.src.rpm
+          path: ${{env.srpm}}
+      
+      # if new release upload rpm to release
+      - name: upload rpm's to new release
+        if: env.version != ''
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{env.x86_rpm}}
+          asset_name: secvarctl-${{env.version}}.x86_64.rpm
+          asset_content_type: application/octet-stream
+             
+      # if new release upload srpm to release
+      - name: upload srpm's to new release
+        if: env.version != ''
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{env.srpm}}
+          asset_name: secvarctl-${{env.version}}.src.rpm
+          asset_content_type: application/octet-stream
+          
+      # build rpm's for ppc64le
+      - name: install dependencies for cross compiling
+        run:  sudo dnf install -y gcc-ppc64le-linux-gnu
+      # not really sure why we have to specify the exact filename of the man page this time but it fixes the issues
+      - name: build rpm's for ppc64le
+        run: |
+             cd ~/rpmbuild
+             sed -i s/1\\*/1.gz/g SPECS/secvarctl.spec
+             rpmbuild --target=powerpc64le --define '_smp_build_ncpus `nproc`' -ba SPECS/secvarctl.spec
+             ls -la RPMS/x86_64/
+             echo "ppc64le_rpm=`ls -d ~/rpmbuild/RPMS/powerpc64le/* | head -1`" >> $GITHUB_ENV             
+             
+     # ---------- perform the entire above uploading process again but with power assets this time ---------
+      - name: upload ppc rpm's to github action artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: secvarctl-${{env.version}}.powerpc64le.rpm
+          path: ${{env.ppc64le_rpm}}
+      
+      # if new release upload rpm to release
+      - name: upload ppc64le rpm's to new release
+        if: env.version != ''
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{env.ppc64le_rpm}}
+          asset_name: secvarctl-${{env.version}}.powerpc64le.rpm
+          asset_content_type: application/octet-stream
+
+       
+             

--- a/.github/workflows/build_rpm.yml
+++ b/.github/workflows/build_rpm.yml
@@ -128,37 +128,38 @@ jobs:
           asset_path: ${{env.srpm}}
           asset_name: secvarctl-${{env.version}}.src.rpm
           asset_content_type: application/octet-stream
-          
-      # build rpm's for ppc64le
-      - name: install dependencies for cross compiling
-        run:  sudo dnf install -y gcc-ppc64le-linux-gnu
-      # not really sure why we have to specify the exact filename of the man page this time but it fixes the issues
-      - name: build rpm's for ppc64le
-        run: |
-             cd ~/rpmbuild
-             sed -i s/1\\*/1.gz/g SPECS/secvarctl.spec
-             rpmbuild --target=powerpc64le --define '_smp_build_ncpus `nproc`' -ba SPECS/secvarctl.spec
-             ls -la RPMS/x86_64/
-             echo "ppc64le_rpm=`ls -d ~/rpmbuild/RPMS/powerpc64le/* | head -1`" >> $GITHUB_ENV             
+# TODO building rpm's for power (on x86 and ubuntu) not working correctly
+# for now users can install from source rpm
+#       # build rpm's for ppc64le
+#       - name: install dependencies for cross compiling
+#         run:  sudo dnf install -y gcc-ppc64le-linux-gnu
+#       # not really sure why we have to specify the exact filename of the man page this time but it fixes the issues
+#       - name: build rpm's for ppc64le
+#         run: |
+#              cd ~/rpmbuild
+#              sed -i s/1\\*/1.gz/g SPECS/secvarctl.spec
+#              rpmbuild --target=powerpc64le --define '_smp_build_ncpus `nproc`' -ba SPECS/secvarctl.spec
+#              ls -la RPMS/x86_64/
+#              echo "ppc64le_rpm=`ls -d ~/rpmbuild/RPMS/powerpc64le/* | head -1`" >> $GITHUB_ENV             
              
-     # ---------- perform the entire above uploading process again but with power assets this time ---------
-      - name: upload ppc rpm's to github action artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: secvarctl-${{env.version}}.powerpc64le.rpm
-          path: ${{env.ppc64le_rpm}}
+#      # ---------- perform the entire above uploading process again but with power assets this time ---------
+#       - name: upload ppc rpm's to github action artifacts
+#         uses: actions/upload-artifact@v2
+#         with:
+#           name: secvarctl-${{env.version}}.powerpc64le.rpm
+#           path: ${{env.ppc64le_rpm}}
       
-      # if new release upload rpm to release
-      - name: upload ppc64le rpm's to new release
-        if: env.version != ''
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{env.ppc64le_rpm}}
-          asset_name: secvarctl-${{env.version}}.powerpc64le.rpm
-          asset_content_type: application/octet-stream
+#       # if new release upload rpm to release
+#       - name: upload ppc64le rpm's to new release
+#         if: env.version != ''
+#         uses: actions/upload-release-asset@v1
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         with:
+#           upload_url: ${{ github.event.release.upload_url }}
+#           asset_path: ${{env.ppc64le_rpm}}
+#           asset_name: secvarctl-${{env.version}}.powerpc64le.rpm
+#           asset_content_type: application/octet-stream
 
        
              

--- a/.github/workflows/x86_CI.yml
+++ b/.github/workflows/x86_CI.yml
@@ -1,0 +1,59 @@
+name: x86 Make CI
+
+on: ['push']
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: install openssl nad valgrind for running test script
+      run:  sudo apt install openssl valgrind
+    - name: install mbedtls
+      run:  sudo apt install libmbedtls-dev
+    - name: build with mbedtls
+      run: make secvarctl-cov
+    - name: test mbedtls build
+      run: |
+        cd test
+        make MEMCHECK=1
+        make clean
+        cd ..
+        make clean
+        
+    - name: install  openssl-libs
+      run:  sudo apt install  libssl-dev
+    - name: build with openssl
+      run: make OPENSSL=1 secvarctl-cov
+    - name: test openssl build
+      run: |
+        cd test
+        make OPENSSL=1 MEMCHECK=1
+        make clean
+        cd ..
+        make clean
+    
+    - name: run and test cmake builds
+      run: |
+        sudo apt install cmake
+        mkdir build
+        cd build
+        cmake ../ .
+        cmake --build .
+        mv  secvarctl ../secvarctl-cov
+        cd ../test
+        make
+        make clean 
+        cd ../build
+        rm -r *
+        cmake ../ -DOPENSSL=1 .
+        cmake --build .
+        mv  secvarctl ../secvarctl-cov
+        cd ../test
+        make OPENSSL=1
+        make clean
+        cd ..
+        
+  


### PR DESCRIPTION
Hello,

This pull request adds two new workflows to secvarctl:
1. run CI tests on every push and pull request
2. build x86 rpm and source rpm on every release

Some notes on these:
- CI tests run  on an Ubuntu x86 github runner, it does not seem that github supports actions on other architectures
- I initially thought I could cross compile a ppc64le rpm, it builds but when I try to install on a ppc64le machine I fail to install
- Since ppc64le rpm is failing, for now I commented that part of the workflow out and figured the source rpm would be sufficient