### PR TITLE
crypto: Fix openssl implementation of crypto_x509_is_RSA

### DIFF
--- a/backends/edk2-compat/edk2-svc-validate.c
+++ b/backends/edk2-compat/edk2-svc-validate.c
@@ -522,9 +522,13 @@ static int validateCertStruct(crypto_x509 *x509, const char *varName)
 	// if public key type is not RSA, then quit (example failures: DSA, ECDSA, RSA_PCC)
 	rc = crypto_x509_is_RSA(x509);
 	if (rc) {
-		prlog(PR_ERR,
-		      "ERROR: public key type not supported, expected RSA, found type ID %d (defined by crypto lib)\n",
-		      rc);
+		// openssl implementation for crypto_x509_is_RSA could return secvarctl's CERT_FAL no type found
+		if (rc == CERT_FAIL)
+			prlog(PR_ERR, "ERROR: public key type not able to be parsed from x509\n");
+		else
+			prlog(PR_ERR,
+			      "ERROR: public key type not supported, expected RSA, found type ID %d (defined by crypto lib)\n",
+			      rc);
 		return CERT_FAIL;
 	}
 


### PR DESCRIPTION
This pull request is to fix a bug identified by @daxtens . Thanks Daniel.
There were two issues in the openssl implementation of `crypto_x509_is_RSA`.
First, the function would return NULL on an error which would be converted to 0 
when typecast to an int. This would slip through the conditionals and return as a success.
Second, we were attempting to read the signature algorithm used to sign the x509, in reality
we wanted to get the type of the public key. 
