### PR TITLE
Static Analysis Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,9 +166,13 @@ memcheck: secvarctl-cov
 	                 SECVAR_TOOL=$(SECVAR_TOOL) \
 	                 memcheck
 
+
+CPPCHECK_FLAGS =  --enable=all --force -q
+CPPCHECK_FLAGS += --suppress=missingIncludeSystem
+CPPCHECK_FLAGS += --suppress=unusedFunction       # false positive on validateTS
+CPPCHECK_FLAGS += --suppress=internalAstError     # false positive on ccan/list_for_each
 cppcheck:
-	cppcheck --enable=all --suppress=missingIncludeSystem --force -q \
-	         $(INCLUDES) $(MAIN_SRCS)
+	cppcheck $(CPPCHECK_FLAGS) $(INCLUDES) $(MAIN_SRCS)
 
 generate:
 	@$(MAKE) -C test generate MEMCHECK=$(MEMCHECK) OPENSSL=$(OPENSSL) GNUTLS=$(GNUTLS) \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ BIN_DIR = bin
 OBJ_DIR = obj
 
 # TODO: seriously trim down the number of -I includes. use more relative pathing.
-INCLUDES = -I./include                               \
+INCLUDES = -I.                                       \
+           -I./include                               \
            -I./external/libstb-secvar/               \
            -I./external/libstb-secvar/include        \
            -I./external/libstb-secvar/include/secvar
@@ -167,7 +168,7 @@ memcheck: secvarctl-cov
 
 cppcheck:
 	cppcheck --enable=all --suppress=missingIncludeSystem --force -q \
-	         $(MAIN_SRCS) $(INCLUDE)
+	         $(INCLUDES) $(MAIN_SRCS)
 
 generate:
 	@$(MAKE) -C test generate MEMCHECK=$(MEMCHECK) OPENSSL=$(OPENSSL) GNUTLS=$(GNUTLS) \

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,10 @@ memcheck: secvarctl-cov
 	                 SECVAR_TOOL=$(SECVAR_TOOL) \
 	                 memcheck
 
+cppcheck:
+	cppcheck --enable=all --suppress=missingIncludeSystem --force -q \
+	         $(MAIN_SRCS) $(INCLUDE)
+
 generate:
 	@$(MAKE) -C test generate MEMCHECK=$(MEMCHECK) OPENSSL=$(OPENSSL) GNUTLS=$(GNUTLS) \
 	                 HOST_BACKEND=$(HOST_BACKEND) \

--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -100,10 +100,10 @@ int create_esl(const uint8_t *data, const size_t data_size, const uuid_t guid, u
 
 	esl.signature_type = guid;
 	esl.signature_list_size = sizeof(esl) + sizeof(uuid_t) + data_size;
-	prlog(PR_INFO, "\tsig list size - %d\n", esl.signature_list_size);
+	prlog(PR_INFO, "\tsig list size - %u\n", esl.signature_list_size);
 	esl.signature_header_size = 0;
 	esl.signature_size = data_size + sizeof(uuid_t);
-	prlog(PR_INFO, "\tsignature data size - %d\n", esl.signature_size);
+	prlog(PR_INFO, "\tsignature data size - %u\n", esl.signature_size);
 
 	/*esl structure:
       -esl header - 28 bytes
@@ -148,13 +148,13 @@ int extract_esl_from_auth(const uint8_t *data, const size_t data_size, uint8_t *
 	auth = (auth_info_t *)data;
 	length = auth->auth_cert.hdr.da_length;
 	if (length == 0 || length > data_size) { /* if total size of header and pkcs7 */
-		prlog(PR_ERR, "error: invalid auth size %zd\n", length);
+		prlog(PR_ERR, "error: invalid auth size %zu\n", length);
 		return AUTH_FAIL;
 	}
 
 	pkcs7_size = extract_pkcs7_len(auth);
 	if (pkcs7_size == 0 || pkcs7_size > length) {
-		prlog(PR_ERR, "error: invalid pkcs7 size %zd\n", pkcs7_size);
+		prlog(PR_ERR, "error: invalid pkcs7 size %zu\n", pkcs7_size);
 		return PKCS7_FAIL;
 	}
 
@@ -170,8 +170,8 @@ int extract_esl_from_auth(const uint8_t *data, const size_t data_size, uint8_t *
 	}
 
 	prlog(PR_NOTICE,
-	      "\tauth file size = %zd\n\t  -auth/pkcs7 data size = %zd\n\t"
-	      "  -esl size = %zd\n",
+	      "\tauth file size = %zu\n\t  -auth/pkcs7 data size = %zu\n\t"
+	      "  -esl size = %zu\n",
 	      data_size, auth_buffer_size, data_size - auth_buffer_size);
 
 	/* skips over entire pkcs7 in cert_datas */
@@ -278,7 +278,7 @@ int create_presigned_hash(const uint8_t *esl, const size_t esl_size,
 	if (rc)
 		prlog(PR_ERR, "failed to generate hash\n");
 	else if (*out_buffer_size != 32) {
-		prlog(PR_ERR, "error: size of sha256 is not 32 bytes, found %zd bytes\n",
+		prlog(PR_ERR, "error: size of sha256 is not 32 bytes, found %zu bytes\n",
 		      *out_buffer_size);
 		rc = HASH_FAIL;
 	}
@@ -396,13 +396,13 @@ int create_auth_msg(const uint8_t *new_esl, const size_t new_esl_size,
 	prlog(PR_INFO, "\t+ append header %d bytes\n", APPEND_HEADER_LEN);
 	memcpy(*out_buffer + offset, &auth_header, sizeof(auth_header));
 	offset += sizeof(auth_header);
-	prlog(PR_INFO, "\t+ auth header %ld bytes\n", sizeof(auth_header));
+	prlog(PR_INFO, "\t+ auth header %zu bytes\n", sizeof(auth_header));
 	memcpy(*out_buffer + offset, pkcs7, pkcs7_size);
 	offset += pkcs7_size;
-	prlog(PR_INFO, "\t+ pkcs7 %zd bytes\n", pkcs7_size);
+	prlog(PR_INFO, "\t+ pkcs7 %zu bytes\n", pkcs7_size);
 	memcpy(*out_buffer + offset, new_esl, new_esl_size);
 	offset += new_esl_size;
-	prlog(PR_INFO, "\t+ new esl %zd bytes\n\t= %zd total bytes\n", new_esl_size, offset);
+	prlog(PR_INFO, "\t+ new esl %zu bytes\n\t= %zu total bytes\n", new_esl_size, offset);
 
 	free(pkcs7);
 

--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -147,13 +147,13 @@ int extract_esl_from_auth(const uint8_t *data, const size_t data_size, uint8_t *
 
 	auth = (auth_info_t *)data;
 	length = auth->auth_cert.hdr.da_length;
-	if (length <= 0 || length > data_size) { /* if total size of header and pkcs7 */
+	if (length == 0 || length > data_size) { /* if total size of header and pkcs7 */
 		prlog(PR_ERR, "error: invalid auth size %zd\n", length);
 		return AUTH_FAIL;
 	}
 
 	pkcs7_size = extract_pkcs7_len(auth);
-	if (pkcs7_size <= 0 || pkcs7_size > length) {
+	if (pkcs7_size == 0 || pkcs7_size > length) {
 		prlog(PR_ERR, "error: invalid pkcs7 size %zd\n", pkcs7_size);
 		return PKCS7_FAIL;
 	}

--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -244,8 +244,7 @@ static int create_prehash(const uint8_t *esl, const size_t esl_size,
 	ptr += sizeof(*args->time);
 	memcpy(ptr, esl, esl_size);
 
-	if (wkey != NULL)
-		free(wkey);
+	free(wkey);
 
 	return rc;
 }
@@ -400,8 +399,7 @@ int create_auth_msg(const uint8_t *new_esl, const size_t new_esl_size,
 	offset += new_esl_size;
 	prlog(PR_INFO, "\t+ new esl %zd bytes\n\t= %zd total bytes\n", new_esl_size, offset);
 
-	if (pkcs7 != NULL)
-		free(pkcs7);
+	free(pkcs7);
 
 	return rc;
 }

--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -10,7 +10,7 @@
 #include "err.h"
 #include "prlog.h"
 #include "crypto.h"
-#include "endian.h"
+#include <endian.h>
 #include "common/util.h"
 #include "common/generate.h"
 #include "common/validate.h"

--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -360,6 +360,11 @@ int create_auth_msg(const uint8_t *new_esl, const size_t new_esl_size,
 	uint8_t *pkcs7 = NULL, *append_header = NULL;
 	auth_info_t auth_header;
 
+	if (out_buffer == NULL) {
+		prlog(PR_ERR, "out_buffer was NULL, this is likely a bug");
+		return ALLOC_FAIL; // Not entirely true, but there's not a better error for this yet
+	}
+
 	rc = create_pkcs7(new_esl, new_esl_size, args, guid, &pkcs7, &pkcs7_size);
 	if (rc != SUCCESS) {
 		prlog(PR_ERR, "ERROR: cannot generate auth file, failed to generate pkcs7\n");
@@ -379,7 +384,7 @@ int create_auth_msg(const uint8_t *new_esl, const size_t new_esl_size,
 	/* now build auth msg = append header + auth header + pkcs7 + new esl */
 	*out_buffer_size = APPEND_HEADER_LEN + sizeof(auth_header) + pkcs7_size + new_esl_size;
 	*out_buffer = malloc(*out_buffer_size);
-	if (out_buffer == NULL) {
+	if (*out_buffer == NULL) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 		free(pkcs7);
 		return ALLOC_FAIL;

--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -124,14 +124,17 @@ int print_variables(const uint8_t *buffer, size_t buffer_size, const uint8_t *va
 {
 	int rc;
 	ssize_t esl_data_size = buffer_size, cert_size;
-	size_t esl_size = 0, next_esl_size = 0, data_size = 0;
-	size_t sig_offset = 0, signature_size = 0, count = 0, offset = 0;
+	size_t count = 0, offset = 0;
 	uint8_t *cert = NULL, *signature_type = NULL, *esl_data = (uint8_t *)buffer;
 	sv_esl_t *sig_list;
 	sv_esd_t *esd = NULL;
 	crypto_x509_t *x509 = NULL;
 
 	while (esl_data_size > 0) {
+		// TODO: consider breaking this down into functions, to avoid these scope reductions
+		size_t esl_size, next_esl_size, sig_offset;
+		size_t signature_size;
+
 		if (esl_data_size < sizeof(sv_esl_t)) {
 			prlog(PR_ERR,
 			      "ERROR: ESL has %zd bytes and is smaller than an ESL (%zd bytes),"
@@ -159,6 +162,8 @@ int print_variables(const uint8_t *buffer, size_t buffer_size, const uint8_t *va
 
 		/* reads the esd from esl */
 		while (esl_size > 0) {
+			size_t data_size;
+
 			esd = (sv_esd_t *)(esl_data + (offset + sig_offset));
 			data_size = signature_size - sizeof(sv_esd_t);
 			cert = esd->signature_data;

--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -80,7 +80,7 @@ void print_signature_type(const void *sig)
 /* prints info on ESL, nothing on ESL data */
 void print_esl_info(sv_esl_t *sig_list)
 {
-	printf("\tESL SIG LIST SIZE: %d\n", sig_list->signature_list_size);
+	printf("\tESL SIG LIST SIZE: %u\n", sig_list->signature_list_size);
 	printf("\tGUID is : ");
 	print_signature_type(&sig_list->signature_type);
 	printf("\tSignature type is: %s\n", get_signature_type(sig_list->signature_type));
@@ -137,7 +137,7 @@ int print_variables(const uint8_t *buffer, size_t buffer_size, const uint8_t *va
 
 		if (esl_data_size < sizeof(sv_esl_t)) {
 			prlog(PR_ERR,
-			      "ERROR: ESL has %zd bytes and is smaller than an ESL (%zd bytes),"
+			      "ERROR: ESL has %zd bytes and is smaller than an ESL (%zu bytes),"
 			      " remaining data not parsed\n",
 			      esl_data_size, sizeof(sv_esl_t));
 			break;
@@ -150,7 +150,7 @@ int print_variables(const uint8_t *buffer, size_t buffer_size, const uint8_t *va
 		signature_type = get_signature_type(sig_list->signature_type);
 
 		if (esl_size < sizeof(sv_esl_t) || esl_size > esl_data_size) {
-			prlog(PR_ERR, "ERROR: invalid ESL size (%lu)\n", esl_size);
+			prlog(PR_ERR, "ERROR: invalid ESL size (%zu)\n", esl_size);
 			break;
 		}
 

--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -165,13 +165,13 @@ int print_variables(const uint8_t *buffer, size_t buffer_size, const uint8_t *va
 			cert_size = data_size;
 
 			if (is_hash(signature_type)) {
-				printf("\tData-%ld: ", count);
+				printf("\tData-%zu: ", count);
 				print_hex(cert, cert_size);
 			} else if (is_cert(signature_type)) {
 				rc = crypto.get_x509_certificate(cert, cert_size, &x509);
 				if (rc)
 					break;
-				printf("\tCertificate-%ld: ", count);
+				printf("\tCertificate-%zu: ", count);
 				rc = print_cert_info(x509);
 				if (rc)
 					break;
@@ -199,7 +199,7 @@ int print_variables(const uint8_t *buffer, size_t buffer_size, const uint8_t *va
 		esl_data_size -= next_esl_size;
 	}
 
-	printf("\tFound %ld ESL's\n\n", count);
+	printf("\tFound %zu ESL's\n\n", count);
 
 	if (x509)
 		crypto.release_x509_certificate(x509);

--- a/backends/guest/common/util.c
+++ b/backends/guest/common/util.c
@@ -4,7 +4,7 @@
  */
 #include <stdlib.h>
 #include <string.h>
-#include "endian.h"
+#include <endian.h>
 #include "err.h"
 #include "prlog.h"
 #include "util.h"

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -234,7 +234,7 @@ int validate_esl(const uint8_t *esl_data, size_t esl_data_len)
 {
 	ssize_t esl_data_size = esl_data_len;
 	size_t esl_size = 0;
-	int count = 0, offset = 0, rc;
+	int count = 0, offset = 0, rc = SUCCESS;
 
 	prlog(PR_INFO, "VALIDATING ESL:\n");
 
@@ -260,7 +260,7 @@ int validate_esl(const uint8_t *esl_data, size_t esl_data_len)
 	if (!count)
 		return ESL_FAIL;
 
-	return SUCCESS;
+	return rc;
 }
 
 /*

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -57,17 +57,17 @@ int validate_time(timestamp_t *time)
 		return INVALID_TIMESTAMP;
 	}
 
-	if (time->hour < 0 || time->hour > 23) {
+	if (time->hour > 23) {
 		prlog(PR_ERR, "ERROR: Invalid Timestamp value for hour: %d\n", time->hour);
 		return INVALID_TIMESTAMP;
 	}
 
-	if (time->minute < 0 || time->minute > 59) {
+	if (time->minute > 59) {
 		prlog(PR_ERR, "ERROR: Invalid Timestamp value for minute: %d\n", time->minute);
 		return INVALID_TIMESTAMP;
 	}
 
-	if (time->second < 0 || time->second > 60) {
+	if (time->second > 60) {
 		prlog(PR_ERR, "ERROR: Invalid Timestamp value for second: %d\n", time->second);
 		return INVALID_TIMESTAMP;
 	}
@@ -129,7 +129,7 @@ static int validate_single_esl(const uint8_t *esl_data, size_t esl_data_size, si
 	/* Get sig list */
 	sig_list = extract_esl_signature_list(esl_data, esl_data_size);
 	if (sig_list->signature_list_size > 0) {
-		if ((sig_list->signature_size <= 0 && sig_list->signature_header_size <= 0) ||
+		if ((sig_list->signature_size == 0 && sig_list->signature_header_size == 0) ||
 		    sig_list->signature_list_size <
 			    (sig_list->signature_header_size + sig_list->signature_size)) {
 			prlog(PR_ERR, "ERROR: signature list is not structured correctly, defined "

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -379,7 +379,7 @@ int validate_auth(const uint8_t *auth_data, size_t auth_data_len)
 
 	if (verbose >= PR_INFO) {
 		prlog(PR_INFO, "\tAPPEND HEADER :\n");
-		printf("\t   Append Flag : %ld\n", append_flag);
+		printf("\t   Append Flag : %zu\n", append_flag);
 	}
 
 	auth_data_len -= APPEND_HEADER_LEN;

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -112,7 +112,6 @@ static int validate_single_esl(const uint8_t *esl_data, size_t esl_data_size, si
 {
 	ssize_t cert_size;
 	int rc;
-	size_t esl_size;
 	uint8_t *cert = NULL, *signature_type = NULL;
 	sv_esl_t *sig_list;
 
@@ -154,14 +153,6 @@ static int validate_single_esl(const uint8_t *esl_data, size_t esl_data_size, si
 	} else if ((int)sig_list->signature_list_size <= 0) {
 		prlog(PR_ERR, "ERROR: signature list has incorrect size %d \n",
 		      sig_list->signature_list_size);
-		return ESL_FAIL;
-	}
-
-	esl_size = sig_list->signature_list_size;
-	if (esl_size > esl_data_size) {
-		prlog(PR_ERR,
-		      "ERROR: signature list size is greater than remaining data size: %zd > %zd\n",
-		      esl_size, esl_data_size);
 		return ESL_FAIL;
 	}
 
@@ -215,7 +206,7 @@ static int validate_single_esl(const uint8_t *esl_data, size_t esl_data_size, si
 	}
 
 	free(cert);
-	*next_esl = esl_size;
+	*next_esl = sig_list->signature_list_size;
 
 	return rc;
 }

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -318,8 +318,10 @@ int validate_cert(const uint8_t *cert_data, size_t cert_data_len)
 {
 	int rc;
 	crypto_x509_t *x509;
+#ifdef SECVAR_CRYPTO_WRITE_FUNC
 	uint8_t *cert = NULL;
 	size_t cert_size = 0;
+#endif
 
 	rc = crypto.get_x509_certificate(cert_data, cert_data_len, &x509);
 	if (rc) {

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -225,12 +225,12 @@ int validate_esl(const uint8_t *esl_data, size_t esl_data_len)
 {
 	ssize_t esl_data_size = esl_data_len;
 	size_t esl_size = 0;
-	int count = 0, offset = 0, rc = SUCCESS;
+	int count = 0, offset = 0;
 
 	prlog(PR_INFO, "VALIDATING ESL:\n");
 
 	while (esl_data_size > 0) {
-		rc = validate_single_esl(esl_data + offset, esl_data_size, &esl_size);
+		int rc = validate_single_esl(esl_data + offset, esl_data_size, &esl_size);
 		/* verify current esl to ensure it is a valid sig_list, if 1 is returned break or error */
 		if (rc) {
 			prlog(PR_ERR, "ERROR: sig List #%d is not structured correctly\n", count);
@@ -251,7 +251,7 @@ int validate_esl(const uint8_t *esl_data, size_t esl_data_len)
 	if (!count)
 		return ESL_FAIL;
 
-	return rc;
+	return SUCCESS;
 }
 
 /*

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -26,7 +26,7 @@ int validate_hash_alg(size_t size, const hash_func_t *alg)
 	if (size != alg->size) {
 		prlog(PR_ERR,
 		      "ERROR: length of hash data does not equal expected size of hash "
-		      "%s, expected %zd found %zd bytes\n",
+		      "%s, expected %zu found %zu bytes\n",
 		      alg->name, alg->size, size);
 		return HASH_FAIL;
 	}
@@ -120,7 +120,7 @@ static int validate_single_esl(const uint8_t *esl_data, size_t esl_data_size, si
 	/* verify struct to ensure it is a valid sig_list, if 1 is returned break */
 	if (esl_data_size < sizeof(sv_esl_t)) {
 		prlog(PR_ERR,
-		      "ERROR: ESL has %zd bytes and is smaller than an ESL (%zd bytes),"
+		      "ERROR: ESL has %zu bytes and is smaller than an ESL (%zu bytes),"
 		      "remaining data not parsed\n",
 		      esl_data_size, sizeof(sv_esl_t));
 		return ESL_FAIL;
@@ -145,13 +145,13 @@ static int validate_single_esl(const uint8_t *esl_data, size_t esl_data_size, si
 	    sig_list->signature_header_size > esl_data_size ||
 	    sig_list->signature_size > esl_data_size) {
 		prlog(PR_ERR,
-		      "ERROR: expected signature list size %d + header size %d + "
-		      "signature size is %d larger than actual size %zd\n",
+		      "ERROR: expected signature list size %u + header size %u + "
+		      "signature size is %u larger than actual size %zu\n",
 		      sig_list->signature_list_size, sig_list->signature_header_size,
 		      sig_list->signature_size, esl_data_size);
 		return ESL_FAIL;
 	} else if ((int)sig_list->signature_list_size <= 0) {
-		prlog(PR_ERR, "ERROR: signature list has incorrect size %d \n",
+		prlog(PR_ERR, "ERROR: signature list has incorrect size %u \n",
 		      sig_list->signature_list_size);
 		return ESL_FAIL;
 	}
@@ -391,7 +391,7 @@ int validate_auth(const uint8_t *auth_data, size_t auth_data_len)
 	auth_size = auth->auth_cert.hdr.da_length + sizeof(auth->timestamp);
 	/* if expected length is greater than the actual length or not a valid size, return fail */
 	if ((ssize_t)auth_size <= 0 || auth_size > auth_data_len) {
-		prlog(PR_ERR, "ERROR: invalid auth size, expected %zd found %zd\n", auth_size,
+		prlog(PR_ERR, "ERROR: invalid auth size, expected %zu found %zu\n", auth_size,
 		      auth_data_len);
 		return AUTH_FAIL;
 	}
@@ -413,12 +413,12 @@ int validate_auth(const uint8_t *auth_data, size_t auth_data_len)
 	pkcs7_size = extract_pkcs7_len(auth);
 	/* ensure pkcs7 size is valid length */
 	if ((ssize_t)pkcs7_size <= 0 || pkcs7_size > auth_size) {
-		prlog(PR_ERR, "ERROR: Invalid pkcs7 size %zd\n", pkcs7_size);
+		prlog(PR_ERR, "ERROR: Invalid pkcs7 size %zu\n", pkcs7_size);
 		return AUTH_FAIL;
 	}
 
 	prlog(PR_INFO,
-	      "\tAuth File Size = %zd\n\t  -Auth/PKCS7 Data Size = %zd\n\t  -ESL Size = %zd\n",
+	      "\tAuth File Size = %zu\n\t  -Auth/PKCS7 Data Size = %zu\n\t  -ESL Size = %zu\n",
 	      auth_data_len, auth_size, auth_data_len - auth_size);
 
 	if (verbose >= PR_INFO) {

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -455,7 +455,7 @@ int validate_variables_arguments(struct verify_args *args)
 {
 	int i = 0;
 
-	if (args->update_variable_size == 0 || args->update_variable_size <= 1) {
+	if (args->update_variable_size <= 1) {
 		prlog(PR_ERR, "ERROR: needs the update variable and respective auth files\n"
 			      " Example: -u <var_name 1> <var_auth_file 1>...<var_name N> "
 			      "<var_auth_file N>\n");

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -383,7 +383,7 @@ static int get_pk_and_kek_from_update_var(const struct verify_args *args, uint8_
  */
 int verify_variables(struct verify_args *args)
 {
-	int rc = SUCCESS, i = 0;
+	int rc = SUCCESS;
 	uint8_t *pk_esl_data = NULL, *kek_esl_data = NULL;
 	size_t pk_esl_data_size = 0, kek_esl_data_size = 0;
 	bool flag = false;
@@ -392,7 +392,7 @@ int verify_variables(struct verify_args *args)
 		rc = get_pk_and_kek_from_path_var(args, &pk_esl_data, &pk_esl_data_size,
 						  &kek_esl_data, &kek_esl_data_size);
 	else if (args->current_variable_size > 0) {
-		for (i = 0; i < args->current_variable_size; i += 2) {
+		for (int i = 0; i < args->current_variable_size; i += 2) {
 			if (memcmp(args->current_variable[i], PK_VARIABLE,
 				   strlen(args->current_variable[i])) == 0)
 				rc = get_current_esl_data((uint8_t *)args->current_variable[i + 1],

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -277,44 +277,46 @@ static int get_pk_and_kek_from_path_var(const struct verify_args *args, uint8_t 
 	char *esl_data = "/data";
 	char *esl_data_path = NULL;
 
-	if (args->variable_path != NULL) {
-		len = strlen(args->variable_path) + PK_LEN + strlen(esl_data);
-		esl_data_path = malloc(len + 1);
-		if (esl_data_path == NULL)
-			return ALLOC_FAIL;
-
-		memset(esl_data_path, 0x00, len + 1);
-		len = 0;
-		memcpy(esl_data_path + len, args->variable_path, strlen(args->variable_path));
-		len += strlen(args->variable_path);
-		memcpy(esl_data_path + len, PK_VARIABLE, PK_LEN);
-		len += PK_LEN;
-		memcpy(esl_data_path + len, esl_data, strlen(esl_data));
-
-		if (is_file(esl_data_path) == SUCCESS)
-			rc = get_current_esl_data((uint8_t *)esl_data_path, pk_esl_data,
-						  pk_esl_data_size);
-
-		free(esl_data_path);
-		len = strlen(args->variable_path) + KEK_LEN + strlen(esl_data);
-		esl_data_path = malloc(len + 1);
-		if (esl_data_path == NULL)
-			return ALLOC_FAIL;
-
-		memset(esl_data_path, 0x00, len + 1);
-		len = 0;
-		memcpy(esl_data_path + len, args->variable_path, strlen(args->variable_path));
-		len += strlen(args->variable_path);
-		memcpy(esl_data_path + len, KEK_VARIABLE, KEK_LEN);
-		len += KEK_LEN;
-		memcpy(esl_data_path + len, esl_data, strlen(esl_data));
-
-		if (is_file(esl_data_path) == SUCCESS)
-			rc = get_current_esl_data((uint8_t *)esl_data_path, kek_esl_data,
-						  kek_esl_data_size);
-
-		free(esl_data_path);
+	if (args->variable_path == NULL) {
+		prlog(PR_ERR, "Path is not set, possibly a bug?");
+		return -1; // Throwaway error, this function likely needs a rewrite
 	}
+
+	len = strlen(args->variable_path) + PK_LEN + strlen(esl_data);
+	esl_data_path = malloc(len + 1);
+	if (esl_data_path == NULL)
+		return ALLOC_FAIL;
+
+	memset(esl_data_path, 0x00, len + 1);
+	len = 0;
+	memcpy(esl_data_path + len, args->variable_path, strlen(args->variable_path));
+	len += strlen(args->variable_path);
+	memcpy(esl_data_path + len, PK_VARIABLE, PK_LEN);
+	len += PK_LEN;
+	memcpy(esl_data_path + len, esl_data, strlen(esl_data));
+
+	if (is_file(esl_data_path) == SUCCESS)
+		rc = get_current_esl_data((uint8_t *)esl_data_path, pk_esl_data, pk_esl_data_size);
+
+	free(esl_data_path);
+	len = strlen(args->variable_path) + KEK_LEN + strlen(esl_data);
+	esl_data_path = malloc(len + 1);
+	if (esl_data_path == NULL)
+		return ALLOC_FAIL;
+
+	memset(esl_data_path, 0x00, len + 1);
+	len = 0;
+	memcpy(esl_data_path + len, args->variable_path, strlen(args->variable_path));
+	len += strlen(args->variable_path);
+	memcpy(esl_data_path + len, KEK_VARIABLE, KEK_LEN);
+	len += KEK_LEN;
+	memcpy(esl_data_path + len, esl_data, strlen(esl_data));
+
+	if (is_file(esl_data_path) == SUCCESS)
+		rc = get_current_esl_data((uint8_t *)esl_data_path, kek_esl_data,
+					  kek_esl_data_size);
+
+	free(esl_data_path);
 
 	return rc;
 }

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -353,8 +353,6 @@ static int get_pk_and_kek_from_update_var(const struct verify_args *args, uint8_
 		rc = get_auth_data((uint8_t *)args->update_variable[i + 1], &auth_data,
 				   &auth_data_size, &append_update);
 		if (rc != SUCCESS) {
-			if (auth_data)
-				free(auth_data);
 			continue;
 		}
 

--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -714,7 +714,7 @@ int guest_generate_command(int argc, char *argv[])
 		goto out;
 	}
 
-	prlog(PR_INFO, "writing %zd bytes to %s\n", out_buffer_size, args.output_file);
+	prlog(PR_INFO, "writing %zu bytes to %s\n", out_buffer_size, args.output_file);
 	/* write data to new file */
 	rc = create_file(args.output_file, (char *)out_buffer, out_buffer_size);
 	if (rc) {

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -184,12 +184,12 @@ static int read_auth(const uint8_t *auth_data, size_t auth_data_len, const int i
 	pkcs7_size = extract_pkcs7_len(auth);
 
 	printf("APPEND HEADER :\n");
-	printf("\tAppend Flag : %ld\n", append_flag);
+	printf("\tAppend Flag : %zu\n", append_flag);
 	printf("AUTH INFO:\n");
 	printf("\tGuid code is : ");
 	print_signature_type(&auth->auth_cert.cert_type);
 	printf("\tType: PKCS7\n");
-	printf("\tAuth File Size = %zd\n\t  -Auth/PKCS7 Data Size = %zd\n\t  -ESL Size = %zd\n",
+	printf("\tAuth File Size = %zu\n\t  -Auth/PKCS7 Data Size = %zu\n\t  -ESL Size = %zu\n",
 	       auth_data_len, auth_size, auth_data_len - auth_size);
 	printf("\tTimestamp: ");
 	print_timestamp(auth->timestamp);

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -172,6 +172,11 @@ static int read_auth(const uint8_t *auth_data, size_t auth_data_len, const int i
 	crypto_pkcs7_t *pkcs7 = NULL;
 	auth_info_t *auth = NULL;
 
+	if (auth_data == NULL) {
+		prlog(PR_ERR, "%s: auth_data is NULL, this is probably a bug", __func__);
+		return ALLOC_FAIL;
+	}
+
 	if (is_print_raw) {
 		print_raw((char *)auth_data, auth_data_len);
 		return rc;

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -208,8 +208,7 @@ static int read_auth(const uint8_t *auth_data, size_t auth_data_len, const int i
 	       crypto.get_signing_cert_from_pkcs7(pkcs7, cert_num, &x509) == SUCCESS) {
 		printf("SIGNING CERTIFICATE:\n");
 
-		if (rc == SUCCESS)
-			rc = print_cert_info(x509);
+		rc = print_cert_info(x509);
 
 		cert_num++;
 	}

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -85,8 +85,6 @@ static int read_cert(const uint8_t *cert_data, const size_t cert_data_len, const
 {
 	int rc = SUCCESS;
 	crypto_x509_t *x509;
-	uint8_t *cert = NULL;
-	size_t cert_size = 0;
 
 	if (is_print_raw) {
 		print_raw((char *)cert_data, cert_data_len);
@@ -101,6 +99,8 @@ static int read_cert(const uint8_t *cert_data, const size_t cert_data_len, const
        * if so we can try to convert pem to der and try again
        */
 #ifdef SECVAR_CRYPTO_WRITE_FUNC
+		uint8_t *cert;
+		size_t cert_size;
 		prlog(PR_INFO, "failed to parse x509 as DER, trying PEM...\n");
 		rc = crypto.get_der_from_pem(cert_data, cert_data_len, &cert, &cert_size);
 		if (rc) {

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -251,7 +251,7 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 		if (rc == SUCCESS) {
 			if (is_print_raw || esl_data_size == DEFAULT_PK_LEN)
 				print_raw((char *)esl_data, esl_data_size);
-			else if (esl_data_size != -1 && (esl_data_size - TIMESTAMP_LEN) != 0)
+			else if (esl_data_size >= TIMESTAMP_LEN)
 				rc = print_variables(esl_data + TIMESTAMP_LEN,
 						     esl_data_size - TIMESTAMP_LEN,
 						     (uint8_t *)variable_name);
@@ -280,8 +280,7 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 				    (esl_data_size == DEFAULT_PK_LEN &&
 				     memcmp(defined_sb_variables[i], PK_VARIABLE, PK_LEN) == 0))
 					print_raw((char *)esl_data, esl_data_size);
-				else if (esl_data_size != -1 &&
-					 (esl_data_size - TIMESTAMP_LEN) != 0)
+				else if (esl_data_size >= TIMESTAMP_LEN)
 					rc = print_variables(esl_data + TIMESTAMP_LEN,
 							     esl_data_size - TIMESTAMP_LEN,
 							     (uint8_t *)defined_sb_variables[i]);

--- a/backends/guest/guest_svc_verify.c
+++ b/backends/guest/guest_svc_verify.c
@@ -69,7 +69,7 @@ static int parse_options(int key, char *arg, struct argp_state *state)
 		if (args->help_flag)
 			break;
 		else if ((rc = validate_variables_arguments(args)) != SUCCESS)
-			return rc;
+			argp_usage(state);
 		break;
 	}
 

--- a/backends/guest/guest_svc_verify.c
+++ b/backends/guest/guest_svc_verify.c
@@ -71,9 +71,6 @@ static int parse_options(int key, char *arg, struct argp_state *state)
 		else if ((rc = validate_variables_arguments(args)) != SUCCESS)
 			return rc;
 		break;
-		argp_usage(state);
-		rc = ARG_PARSE_FAIL;
-		break;
 	}
 
 	if (rc)

--- a/backends/host/host_svc_generate.c
+++ b/backends/host/host_svc_generate.c
@@ -1088,7 +1088,7 @@ static int toAuth(const unsigned char *newESL, size_t eslSize, struct Arguments 
 	// now build auth file, = auth header + pkcs7 + new ESL
 	*outBuffSize = pkcs7Size + sizeof(authHeader) + eslSize;
 	*outBuff = malloc(*outBuffSize);
-	if (!outBuff) {
+	if (!*outBuff) {
 		prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 		rc = ALLOC_FAIL;
 		goto out;

--- a/backends/host/host_svc_generate.c
+++ b/backends/host/host_svc_generate.c
@@ -214,7 +214,7 @@ int performGenerateCommand(int argc, char *argv[])
 		goto out;
 	}
 
-	prlog(PR_INFO, "Writing %zd bytes to %s\n", outBuffSize, args.outFile);
+	prlog(PR_INFO, "Writing %zu bytes to %s\n", outBuffSize, args.outFile);
 	// write data to new file
 	rc = create_file(args.outFile, (char *)outBuff, outBuffSize);
 	if (rc) {
@@ -704,7 +704,7 @@ static int validateHashAndAlg(size_t size, const struct hash_funct *alg)
 {
 	if (size != alg->size) {
 		prlog(PR_ERR,
-		      "ERROR: length of hash data does not equal expected size of hash %s, expected %zd found %zd bytes\n",
+		      "ERROR: length of hash data does not equal expected size of hash %s, expected %zu found %zu bytes\n",
 		      alg->name, alg->size, size);
 		return HASH_FAIL;
 	}
@@ -734,11 +734,11 @@ static int toESL(const unsigned char *data, size_t size, const uuid_t guid, unsi
 	}
 
 	esl.SignatureListSize = sizeof(esl) + sizeof(uuid_t) + size;
-	prlog(PR_INFO, "\tSig List Size - %d\n", esl.SignatureListSize);
+	prlog(PR_INFO, "\tSig List Size - %u\n", esl.SignatureListSize);
 	// for some reason we are using header size is zero in all our files
 	esl.SignatureHeaderSize = 0;
 	esl.SignatureSize = size + sizeof(uuid_t);
-	prlog(PR_INFO, "\tSignature Data Size - %d\n", esl.SignatureSize);
+	prlog(PR_INFO, "\tSignature Data Size - %u\n", esl.SignatureSize);
 
 	/*ESL Structure:
 		-ESL header - 28 bytes
@@ -781,14 +781,14 @@ static int authToESL(const unsigned char *in, size_t inSize, unsigned char **out
 	auth = (struct efi_variable_authentication_2 *)in;
 	length = auth->auth_info.hdr.dw_length;
 	if (length == 0 || length > inSize) { // if total size of header and pkcs7
-		prlog(PR_ERR, "ERROR: Invalid auth size %zd\n", length);
+		prlog(PR_ERR, "ERROR: Invalid auth size %zu\n", length);
 		return AUTH_FAIL;
 	}
 	pkcs7_size = get_pkcs7_len(auth);
 	/*pkcs7_size=length-(sizeof(auth->auth_info.hdr)+sizeof(auth->auth_info.cert_type));*/ // =sizeof cert_data[] AKA pkcs7 data
 	// if total size of header and pkcs7
 	if (pkcs7_size == 0 || pkcs7_size > length) {
-		prlog(PR_ERR, "ERROR: Invalid pkcs7 size %zd\n", pkcs7_size);
+		prlog(PR_ERR, "ERROR: Invalid pkcs7 size %zu\n", pkcs7_size);
 		return PKCS7_FAIL;
 	}
 	/*
@@ -802,7 +802,7 @@ static int authToESL(const unsigned char *in, size_t inSize, unsigned char **out
 		return ESL_FAIL;
 	}
 	prlog(PR_NOTICE,
-	      "\tAuth File Size = %zd\n\t  -Auth/PKCS7 Data Size = %zd\n\t  -ESL Size = %zd\n",
+	      "\tAuth File Size = %zu\n\t  -Auth/PKCS7 Data Size = %zu\n\t  -ESL Size = %zu\n",
 	      inSize, auth_buffer_size, inSize - auth_buffer_size);
 
 	// skips over entire pkcs7 in cert_datas
@@ -902,7 +902,7 @@ static int toHashForSecVarSigning(const unsigned char *ESL, size_t ESL_size, str
 		goto out;
 	}
 	if (*outBuffSize != 32) {
-		prlog(PR_ERR, "ERROR: size of SHA256 is not 32 bytes, found %zd bytes\n",
+		prlog(PR_ERR, "ERROR: size of SHA256 is not 32 bytes, found %zu bytes\n",
 		      *outBuffSize);
 		rc = HASH_FAIL;
 	}
@@ -1104,13 +1104,13 @@ static int toAuth(const unsigned char *newESL, size_t eslSize, struct Arguments 
 	prlog(PR_INFO, "Combining Auth header, PKCS7 and new ESL:\n");
 	memcpy(*outBuff + offset, &authHeader, sizeof(authHeader));
 	offset += sizeof(authHeader);
-	prlog(PR_INFO, "\t+ Auth Header %ld bytes\n", sizeof(authHeader));
+	prlog(PR_INFO, "\t+ Auth Header %zu bytes\n", sizeof(authHeader));
 	memcpy(*outBuff + offset, pkcs7, pkcs7Size);
 	offset += pkcs7Size;
-	prlog(PR_INFO, "\t+ PKCS7 %zd bytes\n", pkcs7Size);
+	prlog(PR_INFO, "\t+ PKCS7 %zu bytes\n", pkcs7Size);
 	memcpy(*outBuff + offset, newESL, eslSize);
 	offset += eslSize;
-	prlog(PR_INFO, "\t+ new ESL %zd bytes\n\t= %zd total bytes\n", eslSize, offset);
+	prlog(PR_INFO, "\t+ new ESL %zu bytes\n\t= %zu total bytes\n", eslSize, offset);
 
 out:
 	if (pkcs7)

--- a/backends/host/host_svc_generate.c
+++ b/backends/host/host_svc_generate.c
@@ -780,14 +780,14 @@ static int authToESL(const unsigned char *in, size_t inSize, unsigned char **out
 
 	auth = (struct efi_variable_authentication_2 *)in;
 	length = auth->auth_info.hdr.dw_length;
-	if (length <= 0 || length > inSize) { // if total size of header and pkcs7
+	if (length == 0 || length > inSize) { // if total size of header and pkcs7
 		prlog(PR_ERR, "ERROR: Invalid auth size %zd\n", length);
 		return AUTH_FAIL;
 	}
 	pkcs7_size = get_pkcs7_len(auth);
 	/*pkcs7_size=length-(sizeof(auth->auth_info.hdr)+sizeof(auth->auth_info.cert_type));*/ // =sizeof cert_data[] AKA pkcs7 data
 	// if total size of header and pkcs7
-	if (pkcs7_size <= 0 || pkcs7_size > length) {
+	if (pkcs7_size == 0 || pkcs7_size > length) {
 		prlog(PR_ERR, "ERROR: Invalid pkcs7 size %zd\n", pkcs7_size);
 		return PKCS7_FAIL;
 	}

--- a/backends/host/host_svc_generate.c
+++ b/backends/host/host_svc_generate.c
@@ -962,6 +962,12 @@ static int getPreHashForSecVar(unsigned char **outData, size_t *outSize, const u
 		goto out;
 	}
 
+	if (!ESL && ESL_size != 0) {
+		prlog(PR_ERR, "%s: ESL is NULL, but ESL_size is not zero this is probably a bug\n",
+		      __func__);
+		return ARG_PARSE_FAIL;
+	}
+
 	if (verbose >= PR_INFO) {
 		prlog(PR_INFO, "Timestamp is : ");
 		printTimestamp(*args->time);
@@ -998,7 +1004,9 @@ static int getPreHashForSecVar(unsigned char **outData, size_t *outSize, const u
 	ptr += sizeof(attr);
 	memcpy(ptr, args->time, sizeof(struct efi_time));
 	ptr += sizeof(*args->time);
-	memcpy(ptr, ESL, ESL_size);
+	// Skip zero-sized memcpy if generating a reset to make static analysis happy
+	if (ESL)
+		memcpy(ptr, ESL, ESL_size);
 
 out:
 	if (wkey)

--- a/backends/host/host_svc_read.c
+++ b/backends/host/host_svc_read.c
@@ -306,7 +306,7 @@ int getSecVar(struct secvar **var, const char *name, const char *fullPath)
 	}
 	if (size != out_size) {
 		prlog(PR_ERR,
-		      "ERROR: expected size of secvar (%zd) is not equal to actual size (%zd)\n",
+		      "ERROR: expected size of secvar (%zu) is not equal to actual size (%zu)\n",
 		      size, out_size);
 		free(c);
 		return INVALID_FILE;
@@ -343,7 +343,7 @@ static int printReadable(const char *c, size_t size, const char *key)
 		size_t eslsize;
 		if (eslvarsize < sizeof(EFI_SIGNATURE_LIST)) {
 			prlog(PR_ERR,
-			      "ERROR: ESL has %zd bytes and is smaller than an ESL (%zd bytes), remaining data not parsed\n",
+			      "ERROR: ESL has %zd bytes and is smaller than an ESL (%zu bytes), remaining data not parsed\n",
 			      eslvarsize, sizeof(EFI_SIGNATURE_LIST));
 			break;
 		}
@@ -364,7 +364,7 @@ static int printReadable(const char *c, size_t size, const char *key)
 		    sigList->SignatureHeaderSize > eslvarsize ||
 		    sigList->SignatureSize > eslvarsize) {
 			prlog(PR_ERR,
-			      "ERROR: Expected Sig List Size %d + Header size %d + Signature Size is %d larger than actual size %zd\n",
+			      "ERROR: Expected Sig List Size %u + Header size %u + Signature Size is %u larger than actual size %zd\n",
 			      sigList->SignatureListSize, sigList->SignatureHeaderSize,
 			      sigList->SignatureSize, eslvarsize);
 			break;
@@ -414,7 +414,7 @@ static int printReadable(const char *c, size_t size, const char *key)
 // prints info on ESL, nothing on ESL data
 void printESLInfo(EFI_SIGNATURE_LIST *sigList)
 {
-	printf("\tESL SIG LIST SIZE: %d\n", sigList->SignatureListSize);
+	printf("\tESL SIG LIST SIZE: %u\n", sigList->SignatureListSize);
 	printf("\tGUID is : ");
 	printGuidSig(&sigList->SignatureType);
 	printf("\tSignature type is: %s\n", getSigType(sigList->SignatureType));
@@ -457,7 +457,7 @@ static int readTS(const char *data, size_t size)
 	// data length must have a timestamp for every variable besides the TS variable
 	if (size != sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1)) {
 		prlog(PR_ERR,
-		      "ERROR: TS variable does not contain data on all the variables, expected %ld bytes of data, found %zd\n",
+		      "ERROR: TS variable does not contain data on all the variables, expected %zu bytes of data, found %zu\n",
 		      sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1), size);
 		return INVALID_TIMESTAMP;
 	}

--- a/backends/host/host_svc_read.c
+++ b/backends/host/host_svc_read.c
@@ -463,8 +463,7 @@ static int readTS(const char *data, size_t size)
 	}
 
 	for (tmpStamp = (struct efi_time *)data; size > 0;
-	     tmpStamp = (void *)tmpStamp + sizeof(struct efi_time),
-	    size -= sizeof(struct efi_time)) {
+	     tmpStamp = tmpStamp + 1, size -= sizeof(struct efi_time)) {
 		// print variable name
 		printf("\t%s:\t",
 		       variables[(ARRAY_SIZE(variables) - 1) - (size / sizeof(struct efi_time))]);

--- a/backends/host/host_svc_read.c
+++ b/backends/host/host_svc_read.c
@@ -351,7 +351,7 @@ static int printReadable(const char *c, size_t size, const char *key)
 		sigList = get_esl_signature_list(c + offset, eslvarsize);
 		// check size info is logical
 		if (sigList->SignatureListSize > 0) {
-			if ((sigList->SignatureSize <= 0 && sigList->SignatureHeaderSize <= 0) ||
+			if ((sigList->SignatureSize == 0 && sigList->SignatureHeaderSize == 0) ||
 			    sigList->SignatureListSize <
 				    sigList->SignatureHeaderSize + sigList->SignatureSize) {
 				/*printf("Sig List : %d , sig Header: %d, sig Size: %d\n",list.SignatureListSize,list.SignatureHeaderSize,list.SignatureSize);*/

--- a/backends/host/host_svc_read.c
+++ b/backends/host/host_svc_read.c
@@ -332,14 +332,15 @@ int getSecVar(struct secvar **var, const char *name, const char *fullPath)
  */
 static int printReadable(const char *c, size_t size, const char *key)
 {
-	ssize_t eslvarsize = size, cert_size;
-	size_t eslsize = 0;
+	ssize_t eslvarsize = size;
 	int count = 0, offset = 0, rc;
 	unsigned char *cert = NULL;
 	EFI_SIGNATURE_LIST *sigList;
 	crypto_x509 *x509 = NULL;
 
 	while (eslvarsize > 0) {
+		ssize_t cert_size;
+		size_t eslsize;
 		if (eslvarsize < sizeof(EFI_SIGNATURE_LIST)) {
 			prlog(PR_ERR,
 			      "ERROR: ESL has %zd bytes and is smaller than an ESL (%zd bytes), remaining data not parsed\n",

--- a/backends/host/host_svc_validate.c
+++ b/backends/host/host_svc_validate.c
@@ -190,7 +190,7 @@ int validateAuth(const unsigned char *authBuf, size_t buflen, const char *key)
 	authSize = auth->auth_info.hdr.dw_length + sizeof(auth->timestamp);
 	// if expected length is greater than the actual length or not a valid size, return fail
 	if ((ssize_t)authSize <= 0 || authSize > buflen) {
-		prlog(PR_ERR, "ERROR: Invalid auth size, expected %zd found %zd\n", authSize,
+		prlog(PR_ERR, "ERROR: Invalid auth size, expected %zu found %zu\n", authSize,
 		      buflen);
 		return AUTH_FAIL;
 	}
@@ -209,12 +209,12 @@ int validateAuth(const unsigned char *authBuf, size_t buflen, const char *key)
 	pkcs7_size = get_pkcs7_len(auth);
 	// ensure pkcs7 size is valid length
 	if ((ssize_t)pkcs7_size <= 0 || pkcs7_size > authSize) {
-		prlog(PR_ERR, "ERROR: Invalid pkcs7 size %zd\n", pkcs7_size);
+		prlog(PR_ERR, "ERROR: Invalid pkcs7 size %zu\n", pkcs7_size);
 		return AUTH_FAIL;
 	}
 
 	prlog(PR_INFO,
-	      "\tAuth File Size = %zd\n\t  -Auth/PKCS7 Data Size = %zd\n\t  -ESL Size = %zd\n",
+	      "\tAuth File Size = %zu\n\t  -Auth/PKCS7 Data Size = %zu\n\t  -ESL Size = %zu\n",
 	      buflen, authSize, buflen - authSize);
 
 	if (verbose >= PR_INFO) {
@@ -357,7 +357,7 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size
 	// verify struct to ensure it is a valid sigList, if 1 is returned break
 	if (eslvarsize < sizeof(EFI_SIGNATURE_LIST)) {
 		prlog(PR_ERR,
-		      "ERROR: ESL has %zd bytes and is smaller than an ESL (%zd bytes), remaining data not parsed\n",
+		      "ERROR: ESL has %zu bytes and is smaller than an ESL (%zu bytes), remaining data not parsed\n",
 		      eslvarsize, sizeof(EFI_SIGNATURE_LIST));
 		return ESL_FAIL;
 	}
@@ -379,12 +379,12 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size
 	if (sigList->SignatureListSize > eslvarsize || sigList->SignatureHeaderSize > eslvarsize ||
 	    sigList->SignatureSize > eslvarsize) {
 		prlog(PR_ERR,
-		      "ERROR: Expected Sig List Size %d + Header size %d + Signature Size is %d larger than actual size %zd\n",
+		      "ERROR: Expected Sig List Size %u + Header size %u + Signature Size is %u larger than actual size %zu\n",
 		      sigList->SignatureListSize, sigList->SignatureHeaderSize,
 		      sigList->SignatureSize, eslvarsize);
 		return ESL_FAIL;
 	} else if ((int)sigList->SignatureListSize <= 0) {
-		prlog(PR_ERR, "ERROR: Sig List has incorrect size %d \n",
+		prlog(PR_ERR, "ERROR: Sig List has incorrect size %u \n",
 		      sigList->SignatureListSize);
 		return ESL_FAIL;
 	}
@@ -392,7 +392,7 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size
 	// if eslsize is greater than remaining buffer size, error
 	if (eslsize > eslvarsize) {
 		prlog(PR_ERR,
-		      "ERROR: Sig list size is greater than remaining data size: %zd > %zd\n",
+		      "ERROR: Sig list size is greater than remaining data size: %zu > %zu\n",
 		      eslsize, eslvarsize);
 		return ESL_FAIL;
 	}
@@ -467,7 +467,7 @@ int validateCert(const unsigned char *certBuf, size_t buflen, const char *varNam
 	crypto_x509 *x509 = NULL;
 
 	if (buflen == 0) {
-		prlog(PR_ERR, "ERROR: Length %zd is invalid\n", buflen);
+		prlog(PR_ERR, "ERROR: Length %zu is invalid\n", buflen);
 		return CERT_FAIL;
 	}
 	rc = parseX509(&x509, certBuf, buflen);
@@ -606,7 +606,7 @@ static crypto_x509 *parseX509_PEM(const unsigned char *data_pem, size_t data_len
 int parseX509(crypto_x509 **x509, const unsigned char *certBuf, size_t buflen)
 {
 	if ((ssize_t)buflen <= 0) {
-		prlog(PR_ERR, "ERROR: Certificate has invalid length %zd, cannot validate\n",
+		prlog(PR_ERR, "ERROR: Certificate has invalid length %zu, cannot validate\n",
 		      buflen);
 		return CERT_FAIL;
 	}
@@ -664,7 +664,7 @@ int validateTS(const unsigned char *data, size_t size)
 	// data length must have a timestamp for every variable besides the TS variable
 	if (size != sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1)) {
 		prlog(PR_ERR,
-		      "ERROR: TS variable does not contain data on all the variables, expected %ld bytes of data, found %zd\n",
+		      "ERROR: TS variable does not contain data on all the variables, expected %zu bytes of data, found %zu\n",
 		      sizeof(struct efi_time) * (ARRAY_SIZE(variables) - 1), size);
 		return INVALID_TIMESTAMP;
 	}

--- a/backends/host/host_svc_validate.c
+++ b/backends/host/host_svc_validate.c
@@ -543,8 +543,7 @@ static int validateCertStruct(crypto_x509 *x509, const char *varName)
 			prlog(PR_ERR,
 			      "ERROR: Wanted x509 with RSA 2048 and SHA-256. Discovered %s with signature length %d bits\n",
 			      x509_info, crypto_x509_get_pk_bit_len(x509));
-			if (x509_info)
-				free(x509_info);
+			free(x509_info);
 			return CERT_FAIL;
 		}
 	}

--- a/backends/host/host_svc_validate.c
+++ b/backends/host/host_svc_validate.c
@@ -640,7 +640,7 @@ int parseX509(crypto_x509 **x509, const unsigned char *certBuf, size_t buflen)
 	return SUCCESS;
 }
 
-static bool timestamp_is_empty(char *ts_ptr)
+static bool timestamp_is_empty(const char *ts_ptr)
 {
 	for (size_t i = 0; i < sizeof(struct efi_time); i++) {
 		if (ts_ptr[i] != 0x00)

--- a/backends/host/host_svc_validate.c
+++ b/backends/host/host_svc_validate.c
@@ -349,7 +349,6 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size
 {
 	ssize_t cert_size;
 	int rc;
-	size_t eslsize;
 	unsigned char *cert = NULL;
 	EFI_SIGNATURE_LIST *sigList;
 
@@ -386,14 +385,6 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size
 	} else if ((int)sigList->SignatureListSize <= 0) {
 		prlog(PR_ERR, "ERROR: Sig List has incorrect size %u \n",
 		      sigList->SignatureListSize);
-		return ESL_FAIL;
-	}
-	eslsize = sigList->SignatureListSize;
-	// if eslsize is greater than remaining buffer size, error
-	if (eslsize > eslvarsize) {
-		prlog(PR_ERR,
-		      "ERROR: Sig list size is greater than remaining data size: %zu > %zu\n",
-		      eslsize, eslvarsize);
 		return ESL_FAIL;
 	}
 
@@ -436,7 +427,7 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size
 		rc = validateCert(cert, cert_size, varName);
 	}
 	free(cert);
-	*bytesRead = eslsize;
+	*bytesRead = sigList->SignatureListSize;
 
 	return rc;
 }

--- a/backends/host/host_svc_validate.c
+++ b/backends/host/host_svc_validate.c
@@ -610,6 +610,11 @@ int parseX509(crypto_x509 **x509, const unsigned char *certBuf, size_t buflen)
 		      buflen);
 		return CERT_FAIL;
 	}
+	if (x509 == NULL) {
+		prlog(PR_ERR, "x509 is NULL, this is probably a bug");
+		return CERT_FAIL;
+	}
+
 	// returns x509 struct on success or NULL on fail
 	*x509 = crypto_x509_parse_der(certBuf, buflen);
 	if (*x509)

--- a/backends/host/host_svc_validate.c
+++ b/backends/host/host_svc_validate.c
@@ -364,7 +364,7 @@ static int validateSingularESL(size_t *bytesRead, const unsigned char *esl, size
 	sigList = get_esl_signature_list((const char *)esl, eslvarsize);
 	// check size info is logical
 	if (sigList->SignatureListSize > 0) {
-		if ((sigList->SignatureSize <= 0 && sigList->SignatureHeaderSize <= 0) ||
+		if ((sigList->SignatureSize == 0 && sigList->SignatureHeaderSize == 0) ||
 		    sigList->SignatureListSize <
 			    sigList->SignatureHeaderSize + sigList->SignatureSize) {
 			/*printf("Sig List : %d , sig Header: %d, sig Size: %d\n",list.SignatureListSize,list.SignatureHeaderSize,list.SignatureSize);*/
@@ -707,17 +707,17 @@ int validateTime(struct efi_time *time)
 		return INVALID_TIMESTAMP;
 	}
 
-	if (time->hour < 0 || time->hour > 23) {
+	if (time->hour > 23) {
 		prlog(PR_ERR, "ERROR: Invalid Timestamp value for hour: %d\n", time->hour);
 		return INVALID_TIMESTAMP;
 	}
 
-	if (time->minute < 0 || time->minute > 59) {
+	if (time->minute > 59) {
 		prlog(PR_ERR, "ERROR: Invalid Timestamp value for minute: %d\n", time->minute);
 		return INVALID_TIMESTAMP;
 	}
 
-	if (time->second < 0 || time->second > 60) {
+	if (time->second > 60) {
 		prlog(PR_ERR, "ERROR: Invalid Timestamp value for second: %d\n", time->second);
 		return INVALID_TIMESTAMP;
 	}

--- a/backends/host/host_svc_validate.c
+++ b/backends/host/host_svc_validate.c
@@ -308,10 +308,10 @@ int validateESL(const unsigned char *eslBuf, size_t buflen, const char *key)
 {
 	ssize_t eslvarsize = buflen;
 	size_t eslsize = 0;
-	int count = 0, offset = 0, rc;
+	int count = 0, offset = 0;
 	prlog(PR_INFO, "VALIDATING ESL:\n");
 	while (eslvarsize > 0) {
-		rc = validateSingularESL(&eslsize, eslBuf + offset, eslvarsize, key);
+		int rc = validateSingularESL(&eslsize, eslBuf + offset, eslvarsize, key);
 		// verify current esl to ensure it is a valid sigList, if 1 is returned break or error
 		if (rc) {
 			prlog(PR_ERR, "ERROR: Sig List #%d is not structured correctly\n", count);
@@ -494,7 +494,6 @@ out:
 static int validateCertStruct(crypto_x509 *x509, const char *varName)
 {
 	int rc, len, version;
-	char *x509_info;
 	// check raw cert data has data
 	len = crypto_x509_get_der_len(x509);
 	if (len < 0) {
@@ -544,7 +543,7 @@ static int validateCertStruct(crypto_x509 *x509, const char *varName)
 		if (crypto_x509_md_is_sha256(x509) || crypto_x509_oid_is_pkcs1_sha256(x509) ||
 		    crypto_x509_get_pk_bit_len(x509) != 2048) {
 			// calloc to ensure null terminator
-			x509_info = calloc(CERT_BUFFER_SIZE, 1);
+			char *x509_info = calloc(CERT_BUFFER_SIZE, 1);
 			if (!x509_info) {
 				prlog(PR_ERR, "ERROR: failed to allocate memory\n");
 				return CERT_FAIL;

--- a/backends/host/host_svc_verify.c
+++ b/backends/host/host_svc_verify.c
@@ -374,7 +374,6 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 		for (int i = 0; i < currCount; i++)
 			free(currentVars[i]);
 		free(currentVars);
-		currentVars = NULL;
 	}
 
 	return SUCCESS;

--- a/backends/host/host_svc_verify.c
+++ b/backends/host/host_svc_verify.c
@@ -180,7 +180,7 @@ static int parse_opt(int key, char *arg, struct argp_state *state)
 		// check that all essential args are given and valid
 		if (args->helpFlag)
 			break;
-		if (!args->updateVarCount || args->updateVarCount <= 1)
+		if (args->updateVarCount <= 1)
 			argp_usage(state);
 		//	prlog(PR_ERR, "ERROR: No update variables/files given, use -u "
 		//		      "<varName_1> <authFileForVar_1>...\n\t\t"

--- a/backends/host/host_svc_verify.c
+++ b/backends/host/host_svc_verify.c
@@ -328,6 +328,7 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 		// unlikely fail, if alloc fails
 		if (getCurrentVars(currentVars, &currCount, path)) {
 			prlog(PR_ERR, "Could not get current variables from path %s\n", path);
+			free(currentVars);
 			return INVALID_FILE;
 		}
 	}

--- a/generic.c
+++ b/generic.c
@@ -84,7 +84,7 @@ char *get_data_from_file(const char *fullPath, size_t max_bytes, size_t *size)
 	if (max_bytes > fileInfo.st_size)
 		max_bytes = fileInfo.st_size;
 
-	prlog(PR_NOTICE, "----opening %s is success: reading %ld bytes----\n", fullPath, max_bytes);
+	prlog(PR_NOTICE, "----opening %s is success: reading %zu bytes----\n", fullPath, max_bytes);
 
 	buffer = malloc(max_bytes);
 	if (!buffer) {
@@ -132,7 +132,7 @@ int write_data_to_file(const char *file, const char *buff, size_t size)
 	} else if (rc == 0)
 		prlog(PR_WARNING, "End of file reached, not all of file was written to %s\n", file);
 	else
-		prlog(PR_NOTICE, "%d/%zd bytes successfully written from file to %s\n", rc, size,
+		prlog(PR_NOTICE, "%d/%zu bytes successfully written from file to %s\n", rc, size,
 		      file);
 
 	close(fptr);
@@ -166,7 +166,7 @@ int create_file(const char *file, const char *buff, size_t size)
 	} else if (rc == 0)
 		prlog(PR_WARNING, "End of file reached, not all of file was written to %s\n", file);
 	else
-		prlog(PR_NOTICE, "%d/%zd bytes successfully written from file to %s\n", rc, size,
+		prlog(PR_NOTICE, "%d/%zu bytes successfully written from file to %s\n", rc, size,
 		      file);
 
 	close(fptr);
@@ -191,7 +191,7 @@ int realloc_array(void **arr, size_t new_length, size_t size_each)
 	old_arr = *arr;
 	/* check if requested size is too big */
 	if (__builtin_mul_overflow(new_length, size_each, &new_size)) {
-		prlog(PR_ERR, "ERROR: Invalid size to alloc %zd * %zd\n", new_length, size_each);
+		prlog(PR_ERR, "ERROR: Invalid size to alloc %zu * %zu\n", new_length, size_each);
 		goto out;
 	}
 

--- a/generic.c
+++ b/generic.c
@@ -31,16 +31,6 @@ int is_file(const char *path)
 	return SUCCESS;
 }
 
-size_t get_leading_whitespace(unsigned char *data, size_t dataSize)
-{
-	size_t whiteSpaceSize = 0;
-
-	while ((whiteSpaceSize < dataSize) && data[whiteSpaceSize] == 0x00)
-		whiteSpaceSize++;
-
-	return whiteSpaceSize;
-}
-
 void print_hex(unsigned char *data, size_t length)
 {
 	int i;

--- a/include/generic.h
+++ b/include/generic.h
@@ -17,7 +17,6 @@ int write_data_to_file(const char *file, const char *buff, size_t size);
 int create_file(const char *file, const char *buff, size_t size);
 void print_raw(const char *c, size_t size);
 int is_file(const char *path);
-size_t get_leading_whitespace(unsigned char *data, size_t dataSize);
 void print_hex(unsigned char *data, size_t length);
 int realloc_array(void **arr, size_t new_length, size_t size_each);
 


### PR DESCRIPTION
This PR adds a new `make cppcheck` build target to run the `cppcheck` static analysis tool on the source files. The rest of this PR is a fix for every single complaint it had, including a few found from `scan-build`.

---

Some highlights:
 - a LOT of incorrect format strings, mostly using `%d` with unsigned integers (`%u`). Commit messages started getting lazier with these.
 - a worrying amount of `unsigned < 0` comparisons. May warrant a larger audit of all size checks and size arithmetic, I fear there may be possible cases of unsigned wrapping.
 - a few function overhauls, as the errors that were reported were too messy to fix in a simple manner. These should have more detailed commit messages

---
NOTE: A subsequent PR will re-enable Actions, and will run both of these tools.