### PR TITLE
Replace valgrind with ASAN/UBSAN, overhaul debug build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,11 @@
 # - backups and editor gunk
 *.swp
 *~
+compile_commands.json
+.cache
 # build products and coverage data
 obj
-lib
-build
+bin
 # final binaries
 secvarctl
-secvarctl-cov
+secvarctl-dbg

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ DEPS = $(OBJS:.o=.d)
 _CFLAGS += $(CFLAGS) $(INCLUDES)
 _LDFLAGS += $(LDFLAGS)
 
+ifneq ($(DISABLE_ASAN),1)
 SANITIZE_FLAGS = -fsanitize=address              \
                  -fsanitize=undefined            \
                  -fno-sanitize-recover=all       \
@@ -121,6 +122,7 @@ SANITIZE_FLAGS = -fsanitize=address              \
                  -fsanitize=float-cast-overflow  \
                  -fno-sanitize=null              \
                  -fno-sanitize=alignment
+endif
 
 DEBUG_CFLAGS = -g -O0 --coverage
 RELEASE_CFLAGS = -s -O2

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ OBJS = $(addprefix $(OBJ_DIR)/,$(SRCS:.c=.o))
 OBJDBG = $(patsubst %.o, %.dbg.o,$(OBJS))
 DEPS = $(OBJS:.o=.d)
 
-_CFLAGS += $(CFLAGS) $(INCLUDES)
+_CFLAGS += $(CFLAGS)
 _LDFLAGS += $(LDFLAGS)
 
 ifneq ($(DISABLE_ASAN),1)
@@ -140,7 +140,7 @@ $(OBJ_DIR)/%.o: %.c
 
 $(OBJ_DIR)/%.dbg.o: %.c
 	@mkdir -p $(dir $@)
-	$(CC) $(DEBUG_CFLAGS) $(_CFLAGS) $(SANITIZE_FLAGS) -c  $< -o $@
+	$(CC) $(DEBUG_CFLAGS) $(_CFLAGS) $(SANITIZE_FLAGS) $(INCLUDES) -c  $< -o $@
 
 $(BIN_DIR)/secvarctl: $(OBJS) $(LIBSTB_SECVAR)
 	@mkdir -p $(BIN_DIR)

--- a/test/Makefile
+++ b/test/Makefile
@@ -4,11 +4,10 @@ py = python3
 #add location of efitools here. if in PATH, leave blank
 efitools = ../../efitools/
 host_data = host/testdata/PK_by_PK.auth
-SECVAR_TOOL ?= $(PWD)/../bin/secvarctl-cov
+SECVAR_TOOL ?= $(PWD)/../bin/secvarctl-dbg
 
 #By default host backend static library created
 DYNAMIC_LIB = 0
-MEMCHECK = 0
 #run tests against secvarctl compiled with openssl
 OPENSSL = 1
 GNUTLS = 0
@@ -17,25 +16,21 @@ GUEST_BACKEND = 1
 
 define test_host
 	@cd host/ && \
-	$(py) runTests.py -m $(1) -s $(SECVAR_TOOL) && \
-	$(py) runSvcGenerateTests.py -m $(1) -o $(OPENSSL) -g $(GNUTLS) -s $(SECVAR_TOOL)
+	$(py) runTests.py -s $(SECVAR_TOOL) && \
+	$(py) runSvcGenerateTests.py -o $(OPENSSL) -g $(GNUTLS) -s $(SECVAR_TOOL)
 endef
 
 define test_guest
 	@cd guest/ && \
-	$(py) guest_tests.py -m $(1) -s $(SECVAR_TOOL)
+	$(py) guest_tests.py -s $(SECVAR_TOOL)
 endef
 
 # TODO: skip tests if a backend isn't enabled
 all: check
 check: check-host check-guest
-memcheck: memcheck-host memcheck-guest
 
 check-%:
-	$(call $(patsubst check-%,test_%,$@),0)
-
-memcheck-%:
-	$(call $(patsubst memcheck-%,test_%,$@),1)
+	$(call $(patsubst check-%,test_%,$@))
 
 generate: $(host_data)
 ifeq ($(strip $(HOST_BACKEND)), 1)
@@ -56,4 +51,4 @@ clean:
 	rm -rf guest/*.txt guest/generated-data guest/testenv guest/log
 	rm -rf host/*.txt host/generatedTestData host/testenv
 
-.PHONY: all coverage clean check memcheck check-% memcheck-%
+.PHONY: all coverage clean check check-%

--- a/test/guest/guest_generate_testdata.py
+++ b/test/guest/guest_generate_testdata.py
@@ -51,7 +51,7 @@ log_dir = "./log"
 if len(sys.argv)>1:
 	secvarctl = [sys.argv[1]]
 else:
-	secvarctl = ["../../bin/secvarctl-cov"]
+	secvarctl = ["../../bin/secvarctl-dbg"]
 
 secvarctl = secvarctl + ["-m", "guest", "generate"]
 

--- a/test/guest/guest_tests.py
+++ b/test/guest/guest_tests.py
@@ -8,7 +8,7 @@ import sys
 import argparse
 
 MEM_ERR = 101
-SECTOOLS = ["../../bin/secvarctl-cov", "-m", "guest"]
+SECTOOLS = ["../../bin/secvarctl-dbg", "-m", "guest"]
 SECVARPATH = "/sys/firmware/secvar/vars/"
 MEMCHECK = False
 

--- a/test/host/runSvcGenerateTests.py
+++ b/test/host/runSvcGenerateTests.py
@@ -485,6 +485,7 @@ if __name__ == '__main__':
             GNUTLS = args.gnutls
         if args.secvarctl != None:
             SECTOOLS = args.secvarctl
+            GEN[0] = args.secvarctl
 
         del sys.argv[1:]
         createEnvironment()

--- a/test/host/runSvcGenerateTests.py
+++ b/test/host/runSvcGenerateTests.py
@@ -11,7 +11,7 @@ import filecmp
 import argparse
 
 MEM_ERR = 101
-SECTOOLS="../../bin/secvarctl-cov"
+SECTOOLS="../../bin/secvarctl-dbg"
 GEN = [SECTOOLS, "-m", "host", "generate", "-v"]
 OUTDIR = "./generatedTestData/"
 MEMCHECK = False

--- a/test/host/runTests.py
+++ b/test/host/runTests.py
@@ -8,7 +8,7 @@ import sys
 import argparse
 
 MEM_ERR = 101
-SECTOOLS="../../bin/secvarctl-cov"
+SECTOOLS="../../bin/secvarctl-dbg"
 SECVARPATH="/sys/firmware/secvar/vars/"
 MEMCHECK = False
 


### PR DESCRIPTION
Depends on #44 

Valgrind is a great tool, but has a lot of runtime overhead -- especially at startup. We make probably hundreds of calls to `secvarctl`, and therefore invoke valgrind hundreds of times, causing a large amount of time waiting for valgrind to initialize.

This PR adds new support to the `Makefile` for building with address and undefined behavior sanitizers, which introduce a negligible amount of overhead to running the binary, with the benefit of catching even more problems than valgrind.

This comes with a free rework to how testing/debuild builds are handled:
 - `secvarctl-cov` has been renamed to `secvarctl-dbg` (and corresponding build targets)
 - `make debug` is aliased to building the debug binary
 - all `.cov.o` objects are now `.dbg.o`
 - debug build now enables coverage, ASAN/UBSAN by default
 - ASAN/UBSAN can be disabled with `DISABLE_ASAN=1`
 - debug and release flags have been defined separately:
   - debug flags now enable `-g -O0` by default
   - release flags now use `-s -O2` by default
 - in a similar vein `-s` (strip) is no longer enabled on all builds, making debugging stack traces impossible
 - `$(INCLUDES)` is now its own variable and not injected into `$(CFLAGS)` for some reason

NOTE: for the sake of scope, the test runners have been left alone, as those scripts are probably next on my list to clean up a bit. The `MEMCHECK` option for running with valgrind will be removed in a later PR.

TL;DR - all debug builds include coverage support and memcheck'd by default, and tests now run like 20x faster or something.