### PR TITLE
ASAN Fixes

### DIFF
--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -221,7 +221,7 @@ static int create_prehash(const uint8_t *esl, const size_t esl_size,
 
 	/* expand char name to wide character width */
 	varlen = strlen(args->variable_name) * 2;
-	wkey = get_wide_character((uint8_t *)args->variable_name, strlen(args->variable_name));
+	wkey = get_wide_character(args->variable_name, strlen(args->variable_name));
 	if (wkey == NULL)
 		return ALLOC_FAIL;
 

--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -91,10 +91,10 @@ int create_esl(const uint8_t *data, const size_t data_size, const uuid_t guid, u
 	sv_esl_t esl;
 	size_t offset = 0;
 
-	prlog(PR_INFO, "creating esl from %s... adding:\n", get_signature_type(guid));
+	prlog(PR_INFO, "creating esl from %s... adding:\n", get_signature_type_string(guid));
 
 	if (verbose >= PR_INFO) {
-		prlog(PR_INFO, "\t%s guid - ", get_signature_type(guid));
+		prlog(PR_INFO, "\t%s guid - ", get_signature_type_string(guid));
 		print_signature_type(&guid);
 	}
 

--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -242,7 +242,8 @@ static int create_prehash(const uint8_t *esl, const size_t esl_size,
 	ptr += sizeof(attr);
 	memcpy(ptr, args->time, sizeof(timestamp_t));
 	ptr += sizeof(*args->time);
-	memcpy(ptr, esl, esl_size);
+	if (esl)
+		memcpy(ptr, esl, esl_size);
 
 	free(wkey);
 
@@ -400,7 +401,8 @@ int create_auth_msg(const uint8_t *new_esl, const size_t new_esl_size,
 	memcpy(*out_buffer + offset, pkcs7, pkcs7_size);
 	offset += pkcs7_size;
 	prlog(PR_INFO, "\t+ pkcs7 %zu bytes\n", pkcs7_size);
-	memcpy(*out_buffer + offset, new_esl, new_esl_size);
+	if (new_esl)
+		memcpy(*out_buffer + offset, new_esl, new_esl_size);
 	offset += new_esl_size;
 	prlog(PR_INFO, "\t+ new esl %zu bytes\n\t= %zu total bytes\n", new_esl_size, offset);
 

--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -83,8 +83,7 @@ void print_esl_info(sv_esl_t *sig_list)
 	printf("\tESL SIG LIST SIZE: %u\n", sig_list->signature_list_size);
 	printf("\tGUID is : ");
 	print_signature_type(&sig_list->signature_type);
-	printf("\tSignature type is: %s\n",
-	       get_signature_type_string(sig_list->signature_type));
+	printf("\tSignature type is: %s\n", get_signature_type_string(sig_list->signature_type));
 }
 
 /* prints info on x509 */
@@ -121,7 +120,7 @@ int print_cert_info(crypto_x509_t *x509)
  * @param var_name, secure boot variable name
  * @return SUCCESS or error number if failure
  */
-int print_variables(const uint8_t *buffer, size_t buffer_size, const uint8_t *var_name)
+int print_variables(const uint8_t *buffer, size_t buffer_size, const char *var_name)
 {
 	int rc;
 	ssize_t esl_data_size = buffer_size, cert_size;

--- a/backends/guest/common/util.c
+++ b/backends/guest/common/util.c
@@ -6,6 +6,7 @@
 #include <string.h>
 #include <endian.h>
 #include "err.h"
+#include "external/edk2/common.h"
 #include "prlog.h"
 #include "util.h"
 #include "pseries.h"
@@ -17,6 +18,25 @@
 #define SBAT_TYPE (uint8_t *)"SBAT"
 #define DELETE_TYPE (uint8_t *)"DELETE-ALL"
 #define UNKNOWN_TYPE (uint8_t *)"UNKNOWN"
+
+// clang-format off
+const struct signature_type_info signature_type_list[] = {
+	[ST_X509]             = { .name = "X509",       .uuid = &PKS_CERT_X509_GUID },
+	[ST_RSA2048]          = { .name = "RSA2048",    .uuid = &PKS_CERT_RSA2048_GUID },
+	[ST_PKCS7]            = { .name = "PKCS7",      .uuid = &AUTH_CERT_TYPE_PKCS7_GUID },
+	[ST_SBAT]             = { .name = "SBAT",       .uuid = &PKS_CERT_SBAT_GUID },
+	[ST_DELETE]           = { .name = "DELETE-ALL", .uuid = &PKS_CERT_DELETE_GUID },
+	[ST_HASH_SHA1]        = { .name = "SHA1",       .uuid = &PKS_CERT_SHA1_GUID },
+	[ST_HASH_SHA224]      = { .name = "SHA224",     .uuid = &PKS_CERT_SHA224_GUID },
+	[ST_HASH_SHA256]      = { .name = "SHA256",     .uuid = &PKS_CERT_SHA256_GUID },
+	[ST_HASH_SHA384]      = { .name = "SHA384",     .uuid = &PKS_CERT_SHA384_GUID },
+	[ST_HASH_SHA512]      = { .name = "SHA512",     .uuid = &PKS_CERT_SHA512_GUID },
+	[ST_X509_HASH_SHA256] = { .name = "SHA256",     .uuid = &PKS_CERT_X509_SHA256_GUID },
+	[ST_X509_HASH_SHA384] = { .name = "SHA384",     .uuid = &PKS_CERT_X509_SHA384_GUID },
+	[ST_X509_HASH_SHA512] = { .name = "SHA512",     .uuid = &PKS_CERT_X509_SHA512_GUID },
+	[ST_UNKNOWN]          = { .name = "UNKNOWN",    .uuid = NULL},
+};
+// clang-format on
 
 static uint8_t append[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 static uint8_t replace[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
@@ -144,28 +164,12 @@ int get_x509_hash_function(const char *name, hash_func_t **returnfunct)
  */
 uint8_t *get_signature_type(const uuid_t type)
 {
-	for (int i = 0; i < sizeof(x509_hash_functions) / sizeof(hash_func_t); i++) {
-		if (uuid_equals(&type, x509_hash_functions[i].guid))
-			return (uint8_t *)x509_hash_functions[i].name;
+	for (int i = ST_LIST_START; i < ST_UNKNOWN; i++) {
+		if (uuid_equals(&type, signature_type_list[i].uuid))
+			return (uint8_t *)signature_type_list[i].name;
 	}
 
-	for (int i = 0; i < sizeof(hash_functions) / sizeof(hash_func_t); i++) {
-		if (uuid_equals(&type, hash_functions[i].guid))
-			return (uint8_t *)hash_functions[i].name;
-	}
-
-	if (uuid_equals(&type, &PKS_CERT_X509_GUID))
-		return X509_TYPE;
-	else if (uuid_equals(&type, &PKS_CERT_RSA2048_GUID))
-		return RSA2048_TYPE;
-	else if (uuid_equals(&type, &AUTH_CERT_TYPE_PKCS7_GUID))
-		return PKCS7_TYPE;
-	else if (uuid_equals(&type, &PKS_CERT_SBAT_GUID))
-		return SBAT_TYPE;
-	else if (uuid_equals(&type, &PKS_CERT_DELETE_GUID))
-		return DELETE_TYPE;
-
-	return UNKNOWN_TYPE;
+	return (uint8_t *)"UNKNOWN";
 }
 
 /*

--- a/backends/guest/common/util.c
+++ b/backends/guest/common/util.c
@@ -95,7 +95,7 @@ int get_hash_function(const char *name, hash_func_t **returnfunct)
 	int i = 0;
 
 	for (i = 0; i < sizeof(hash_functions) / sizeof(hash_func_t); i++) {
-		if (memcmp(hash_functions[i].name, name, strlen(name)) == 0) {
+		if (strcmp(hash_functions[i].name, name) == 0) {
 			*returnfunct = (hash_func_t *)&hash_functions[i];
 			return SUCCESS;
 		}
@@ -125,7 +125,7 @@ int get_x509_hash_function(const char *name, hash_func_t **returnfunct)
 	int i = 0;
 
 	for (i = 0; i < sizeof(x509_hash_functions) / sizeof(hash_func_t); i++) {
-		if (memcmp(x509_hash_functions[i].name, name, strlen(name)) == 0) {
+		if (strcmp(x509_hash_functions[i].name, name) == 0) {
 			*returnfunct = (hash_func_t *)&x509_hash_functions[i];
 			return SUCCESS;
 		}
@@ -177,7 +177,7 @@ bool is_secure_boot_variable(const char *var)
 	int i = 0;
 
 	for (i = 0; i < defined_sb_variable_len; i++) {
-		if (memcmp((char *)defined_sb_variables[i], var, strlen(var)) == 0)
+		if (strcmp(defined_sb_variables[i], var) == 0)
 			return true;
 	}
 
@@ -191,7 +191,7 @@ bool is_secure_boot_variable(const char *var)
  * @param keylen, length of key
  * @return the new keylen with double length, remember to unalloc
  */
-uint8_t *get_wide_character(const uint8_t *key, const size_t keylen)
+uint8_t *get_wide_character(const char *key, const size_t keylen)
 {
 	int i;
 	uint8_t *str;

--- a/backends/guest/common/util.c
+++ b/backends/guest/common/util.c
@@ -64,19 +64,6 @@ size_t extract_append_header(const uint8_t *auth_info, const size_t auth_len)
 }
 
 /*
- * check it whether given signature type is SBAT or not
- */
-bool is_sbat(const uint8_t *signature_type)
-{
-	size_t len = strlen((char *)signature_type);
-
-	if (memcmp(signature_type, SBAT_TYPE, len) == 0)
-		return true;
-
-	return false;
-}
-
-/*
  * validate the SBAT data format
  */
 bool validate_sbat(const uint8_t *sbat_data, size_t sbat_len)
@@ -162,88 +149,22 @@ int get_x509_hash_function(const char *name, hash_func_t **returnfunct)
  * @param type uuid_t of guid of file
  * @return string of format type, "UNKNOWN" if type doesnt match any known formats
  */
-uint8_t *get_signature_type(const uuid_t type)
+enum signature_type get_signature_type(const uuid_t type)
 {
-	for (int i = ST_LIST_START; i < ST_UNKNOWN; i++) {
+	for (int i = ST_LIST_START; i < ST_LIST_END; i++) {
 		if (uuid_equals(&type, signature_type_list[i].uuid))
-			return (uint8_t *)signature_type_list[i].name;
+			return i;
 	}
 
-	return (uint8_t *)"UNKNOWN";
-}
-
-/*
- * check it whether given signature type is hash or not
- */
-bool is_hash(const uint8_t *signature_type)
-{
-	int i = 0;
-	size_t len = strlen((char *)signature_type);
-
-	for (i = 0; i < sizeof(hash_functions) / sizeof(hash_func_t); i++) {
-		if (memcmp(signature_type, hash_functions[i].name, len) == 0)
-			return true;
-	}
-
-	for (i = 0; i < sizeof(x509_hash_functions) / sizeof(hash_func_t); i++) {
-		if (memcmp(signature_type, x509_hash_functions[i].name, len) == 0)
-			return true;
-	}
-
-	return false;
-}
-
-/*
- * check it whether given signature type is x509 or not
- */
-bool is_cert(const uint8_t *signature_type)
-{
-	size_t len = strlen((char *)signature_type);
-
-	if (memcmp(signature_type, X509_TYPE, len) == 0)
-		return true;
-
-	return false;
-}
-
-/*
- * check it whether given signature type is PKCS7 or not
- */
-bool is_pkcs7(const uint8_t *signature_type)
-{
-	size_t len = strlen((char *)signature_type);
-
-	if (memcmp(signature_type, PKCS7_TYPE, len) == 0)
-		return true;
-
-	return false;
-}
-
-/*
- * check it whether given signature type is DELETE-ALL or not
- */
-bool is_delete(const uint8_t *signature_type)
-{
-	size_t len = strlen((char *)signature_type);
-
-	if (memcmp(signature_type, DELETE_TYPE, len) == 0)
-		return true;
-
-	return false;
+	return ST_UNKNOWN;
 }
 
 /*
  * validates the signature type
  */
-bool validate_signature_type(const uint8_t *signature_type)
+bool validate_signature_type(enum signature_type st)
 {
-	if (is_hash(signature_type))
-		return true;
-
-	if (is_cert(signature_type) || is_sbat(signature_type) || is_delete(signature_type))
-		return true;
-
-	return false;
+	return is_hash(st) || is_cert(st) || is_sbat(st) || is_delete(st);
 }
 
 /*

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -245,6 +245,11 @@ static int verify_update_variable(const struct verify_args *args, const uint8_t 
 					     kek_esl_data, kek_esl_data_size, append_update,
 					     &new_esl_data, &new_esl_data_size);
 
+		free(current_esl_data);
+		free(new_esl_data);
+		current_esl_data = NULL;
+		new_esl_data = NULL;
+
 		if ((rc == SUCCESS || rc == DELETE_EVERYTHING) && args->write_flag &&
 		    args->variable_path != NULL) {
 			rc = write_to_variable(args->variable_path, args->update_variable[i],

--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -16,28 +16,17 @@
 /*
  * check it whether given variable is PK or KEK
  */
-static bool is_global_variable(const uint8_t *variable_name)
+static bool is_global_variable(const char *variable_name)
 {
-	int len = strlen((char *)variable_name);
-
-	if (memcmp(variable_name, PK_VARIABLE, len) == 0 ||
-	    memcmp(variable_name, KEK_VARIABLE, len) == 0)
-		return true;
-
-	return false;
+	return !strcmp(variable_name, PK_VARIABLE) || !strcmp(variable_name, KEK_VARIABLE);
 }
 
 /*
  * check it whether given variable is SBAT
  */
-static bool is_sbat_variable(const uint8_t *variable_name)
+static bool is_sbat_variable(const char *variable_name)
 {
-	int len = strlen((char *)variable_name);
-
-	if (memcmp(variable_name, SBAT_VARIABLE, len) == 0)
-		return true;
-
-	return false;
+	return !strcmp(variable_name, SBAT_VARIABLE);
 }
 
 /*
@@ -67,11 +56,11 @@ static int generate_esl(const uint8_t *buffer, size_t buffer_size, struct genera
 		esl_guid = &PKS_CERT_DELETE_GUID;
 		break;
 	case 'f':
-		if (is_global_variable((uint8_t *)args->variable_name)) {
+		if (is_global_variable(args->variable_name)) {
 			prlog(PR_ERR,
 			      "ERROR: PK and KEK are not allowed to generate hash from file\n");
 			return INVALID_VAR_NAME;
-		} else if (is_sbat_variable((uint8_t *)args->variable_name)) {
+		} else if (is_sbat_variable(args->variable_name)) {
 			if (!validate_sbat(buffer, buffer_size)) {
 				prlog(PR_ERR, "ERROR: invalid SBAT file\n");
 				return INVALID_SBAT;
@@ -250,8 +239,7 @@ static int generate_authorpkcs7(const uint8_t *buffer, size_t buffer_size,
 				      "reset file\n");
 			rc = INVALID_FILE;
 			break;
-		} else if (memcmp(PK_VARIABLE, args->variable_name, strlen(args->variable_name)) ==
-			   0) {
+		} else if (strcmp(PK_VARIABLE, args->variable_name) == 0) {
 			buffer = (const uint8_t *)WIPE_SB_MAGIC;
 			buffer_size = strlen(WIPE_SB_MAGIC);
 		} else
@@ -288,8 +276,7 @@ static int generate_authorpkcs7(const uint8_t *buffer, size_t buffer_size,
 		goto out;
 	}
 
-	var_name = (uint16_t *)get_wide_character((uint8_t *)args->variable_name,
-						  strlen(args->variable_name));
+	var_name = (uint16_t *)get_wide_character(args->variable_name, strlen(args->variable_name));
 	if (var_name == NULL) {
 		rc = ALLOC_FAIL;
 		goto out;
@@ -348,7 +335,7 @@ static int generate_data(const uint8_t *buffer, size_t buffer_size, struct gener
 		rc = CERT_FAIL; /* cannot generate a cert */
 		break;
 	case 'h':
-		if (is_global_variable((uint8_t *)args->variable_name)) {
+		if (is_global_variable(args->variable_name)) {
 			prlog(PR_ERR, "ERROR: PK and KEK are not allowed to generate hash\n");
 			return INVALID_VAR_NAME;
 		}
@@ -529,8 +516,7 @@ static int parse_options(int key, char *arg, struct argp_state *state)
 			      "option\n");
 		else if (args->output_file == NULL)
 			prlog(PR_ERR, "ERROR: no output file given, see usage below...\n");
-		else if (args->append_flag > 0 &&
-			 memcmp(PK_VARIABLE, args->variable_name, strlen(args->variable_name)) == 0)
+		else if (args->append_flag > 0 && strcmp(PK_VARIABLE, args->variable_name) == 0)
 			prlog(PR_ERR, "ERROR: append flag should be 0 for PK\n");
 		else
 			break;

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -81,7 +81,7 @@ static int get_variable_path(const char *path, const char *variable_name, char *
  * @return SUCCESS or error number
  */
 static int read_cert(const uint8_t *cert_data, const size_t cert_data_len, const int is_print_raw,
-		     const uint8_t *variable_name)
+		     const char *variable_name)
 {
 	int rc = SUCCESS;
 	crypto_x509_t *x509;
@@ -140,7 +140,7 @@ static int read_cert(const uint8_t *cert_data, const size_t cert_data_len, const
  * @return SUCCESS or error number
  */
 static int read_esl(const uint8_t *esl_data, const size_t esl_data_len, const int is_print_raw,
-		    const uint8_t *variable_name)
+		    const char *variable_name)
 {
 	int rc = SUCCESS;
 
@@ -164,7 +164,7 @@ static int read_esl(const uint8_t *esl_data, const size_t esl_data_len, const in
  * @return SUCCESS or error number
  */
 static int read_auth(const uint8_t *auth_data, size_t auth_data_len, const int is_print_raw,
-		     const uint8_t *variable_name)
+		     const char *variable_name)
 {
 	int rc = SUCCESS, cert_num = 0;
 	size_t auth_size, pkcs7_size, append_flag;
@@ -257,8 +257,7 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 				print_raw((char *)esl_data, esl_data_size);
 			else if (esl_data_size >= TIMESTAMP_LEN)
 				rc = print_variables(esl_data + TIMESTAMP_LEN,
-						     esl_data_size - TIMESTAMP_LEN,
-						     (uint8_t *)variable_name);
+						     esl_data_size - TIMESTAMP_LEN, variable_name);
 			else
 				prlog(PR_WARNING, "WARNING: The %s database is empty.\n",
 				      variable_name);
@@ -282,12 +281,12 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 			if (rc == SUCCESS) {
 				if (is_print_raw ||
 				    (esl_data_size == DEFAULT_PK_LEN &&
-				     memcmp(defined_sb_variables[i], PK_VARIABLE, PK_LEN) == 0))
+				     strcmp(defined_sb_variables[i], PK_VARIABLE) == 0))
 					print_raw((char *)esl_data, esl_data_size);
 				else if (esl_data_size >= TIMESTAMP_LEN)
 					rc = print_variables(esl_data + TIMESTAMP_LEN,
 							     esl_data_size - TIMESTAMP_LEN,
-							     (uint8_t *)defined_sb_variables[i]);
+							     defined_sb_variables[i]);
 				else
 					prlog(PR_WARNING, "WARNING: The %s database is empty.\n",
 					      defined_sb_variables[i]);
@@ -441,13 +440,13 @@ int guest_read_command(int argc, char *argv[])
 
 	switch (args.input_form) {
 	case CERT_FILE:
-		rc = read_cert(buffer, buffer_size, args.print_raw, (uint8_t *)args.variable_name);
+		rc = read_cert(buffer, buffer_size, args.print_raw, args.variable_name);
 		break;
 	case ESL_FILE:
-		rc = read_esl(buffer, buffer_size, args.print_raw, (uint8_t *)args.variable_name);
+		rc = read_esl(buffer, buffer_size, args.print_raw, args.variable_name);
 		break;
 	case AUTH_FILE:
-		rc = read_auth(buffer, buffer_size, args.print_raw, (uint8_t *)args.variable_name);
+		rc = read_auth(buffer, buffer_size, args.print_raw, args.variable_name);
 		break;
 	default:
 		rc = read_path(args.path, args.print_raw, args.variable_name);

--- a/backends/guest/include/common/read.h
+++ b/backends/guest/include/common/read.h
@@ -61,6 +61,6 @@ void print_timestamp(timestamp_t t);
  * @param key, variable name {"db","dbx","KEK", "PK"} b/c dbx is a different format
  * @return SUCCESS or error number if failure
  */
-int print_variables(const uint8_t *buffer, size_t buffer_size, const uint8_t *key);
+int print_variables(const uint8_t *buffer, size_t buffer_size, const char *var_name);
 
 #endif

--- a/backends/guest/include/common/util.h
+++ b/backends/guest/include/common/util.h
@@ -21,6 +21,34 @@ static const uuid_t PKS_CERT_DELETE_GUID = { { 0x00, 0x00, 0x00, 0x00, 0x00, 0x0
 
 enum file_types { AUTH_FILE, PKCS7_FILE, ESL_FILE, CERT_FILE, UNKNOWN_FILE };
 
+// Enum for each possible signature type
+//  Start at 1, so 0 can be reserved for some kind of error type
+//  Alias ST_LIST_START as the first value for iteration purposes
+enum signature_type {
+	ST_LIST_START = 1,
+	ST_X509 = 1,
+	ST_RSA2048,
+	ST_PKCS7,
+	ST_SBAT,
+	ST_DELETE,
+	ST_HASH_SHA1,
+	ST_HASH_SHA224,
+	ST_HASH_SHA256,
+	ST_HASH_SHA384,
+	ST_HASH_SHA512,
+	ST_X509_HASH_SHA256,
+	ST_X509_HASH_SHA384,
+	ST_X509_HASH_SHA512,
+	ST_UNKNOWN, // NOTE: Expected to be last in the enum for iteration end
+};
+
+struct signature_type_info {
+	const char *name;
+	const uuid_t *uuid;
+};
+
+extern const struct signature_type_info signature_type_list[];
+
 /*
  * creates the append header using append flag
  */

--- a/backends/guest/include/common/util.h
+++ b/backends/guest/include/common/util.h
@@ -154,7 +154,7 @@ bool is_secure_boot_variable(const char *var);
  * @param var_name_len, length of variable name
  * @return the new keylen with double length, remember to unalloc
  */
-uint8_t *get_wide_character(const uint8_t *var_name, const size_t var_name_len);
+uint8_t *get_wide_character(const char *var_name, const size_t var_name_len);
 
 /*
  * Extracts size of the PKCS7 signed data embedded in the

--- a/backends/host/host_svc_generate.c
+++ b/backends/host/host_svc_generate.c
@@ -1078,6 +1078,13 @@ static int toAuth(const unsigned char *newESL, size_t eslSize, struct Arguments 
 	unsigned char *pkcs7 = NULL;
 	struct efi_variable_authentication_2 authHeader;
 
+	if ((newESL == NULL) && (eslSize != 0)) {
+		prlog(PR_ERR, "%s: newESL is NULL but eslSize is nonzero, this is probably a bug\n",
+		      __func__);
+		rc = ALLOC_FAIL;
+		goto out;
+	}
+
 	// generate PKCS7
 	rc = toPKCS7ForSecVar(newESL, eslSize, args, hashFunct, &pkcs7, &pkcs7Size);
 	if (rc) {
@@ -1108,7 +1115,8 @@ static int toAuth(const unsigned char *newESL, size_t eslSize, struct Arguments 
 	memcpy(*outBuff + offset, pkcs7, pkcs7Size);
 	offset += pkcs7Size;
 	prlog(PR_INFO, "\t+ PKCS7 %zu bytes\n", pkcs7Size);
-	memcpy(*outBuff + offset, newESL, eslSize);
+	if (newESL != NULL)
+		memcpy(*outBuff + offset, newESL, eslSize);
 	offset += eslSize;
 	prlog(PR_INFO, "\t+ new ESL %zu bytes\n\t= %zu total bytes\n", eslSize, offset);
 


### PR DESCRIPTION
Depends on #45 , #44 . I goofed on opening the PRs in the right order, merge this before #46 

Apply fixes reported by ASAN/UBSAN.

There are two major reworks included in this, a few smaller ones:
 - replace use of signature type strings with an enum to remove a ton of unnecessary `memcmp`/`strcmp`
 - change use of `uint8_t*` as a string type to `char*`
 - fixed a few memory leaks
 - fixed `memcpy` from `NULL` UB