### PR TITLE
Reimplement CMake-based build system

### DIFF
--- a/.github/workflows/x86_CI.yml
+++ b/.github/workflows/x86_CI.yml
@@ -13,7 +13,7 @@ jobs:
         submodules: 'recursive'
 
     - name: install openssl and valgrind for running test script
-      run:  sudo apt-get update && sudo apt-get install -y openssl valgrind libssl-dev libmbedtls-dev cppcheck
+      run:  sudo apt-get update && sudo apt-get install -y openssl valgrind libssl-dev libmbedtls-dev cppcheck cmake
 
     - name: run cppcheck
       run: make cppcheck
@@ -21,26 +21,10 @@ jobs:
     - name: run test cases
       run: make check
 
-    # TODO: Disabled until cmake build returns
-    # - name: run and test cmake builds
-    #   run: |
-    #     sudo apt install cmake
-    #     mkdir build
-    #     cd build
-    #     cmake ../ .
-    #     cmake --build .
-    #     mv  secvarctl ../secvarctl-cov
-    #     cd ../test
-    #     make
-    #     make clean 
-    #     cd ../build
-    #     rm -r *
-    #     cmake ../ -DOPENSSL=1 .
-    #     cmake --build .
-    #     mv  secvarctl ../secvarctl-cov
-    #     cd ../test
-    #     make OPENSSL=1
-    #     make clean
-    #     cd ..
+    - name: run and test cmake builds
+      run: |
+        cmake -Bbuild . -DUSE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug
+        cmake --build build
+        make check SECVAR_TOOL=$(pwd)/build/secvarctl
         
   

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ compile_commands.json
 # build products and coverage data
 obj
 bin
+build
 # final binaries
 secvarctl
 secvarctl-dbg

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2023 IBM Corp.
+
+cmake_minimum_required( VERSION 3.12 )
+project( secvarctl C )
+
+add_executable( secvarctl )
+
+target_sources( secvarctl PRIVATE secvarctl.c generic.c )
+
+set( INCLUDE_PATHS
+  include/
+  external/libstb-secvar/
+  external/libstb-secvar/include/
+  external/libstb-secvar/include/secvar/
+  external/skiboot/
+  external/skiboot/libstb/
+  external/skiboot/include/
+  external/extraMbedtls/include/
+  backends/host/
+  backends/guest/include/
+)
+
+target_sources( secvarctl PRIVATE
+  external/extraMbedtls/pkcs7.c
+  external/extraMbedtls/pkcs7_write.c
+  external/skiboot/libstb/secvar/secvar_util.c
+  # external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
+  external/skiboot/libstb/secvar/crypto/crypto-openssl.c
+  # external/skiboot/libstb/secvar/crypto/crypto-gnutls.c
+  external/skiboot/libstb/secvar/backend/edk2-compat.c
+  external/skiboot/libstb/secvar/backend/edk2-compat-process.c
+)
+
+include( backends/host/CMakeLists.txt )
+include( backends/guest/CMakeLists.txt )
+
+target_include_directories( secvarctl AFTER PRIVATE ${INCLUDE_PATHS} )
+target_compile_definitions( secvarctl PRIVATE
+  SECVAR_HOST_BACKEND
+  SECVAR_GUEST_BACKEND
+  SECVAR_CRYPTO_WRITE_FUNC
+)
+
+# OpenSSL
+target_compile_definitions( secvarctl PRIVATE SECVAR_CRYPTO_OPENSSL )
+find_package( OpenSSL REQUIRED )
+target_link_libraries( secvarctl OpenSSL::SSL )
+
+# mbedTLS
+find_library( MBEDX509 mbedx509 HINTS ENV PATH REQUIRED )
+find_library( MBEDCRYPTO mbedcrypto HINTS ENV PATH REQUIRED )
+find_library( MBEDTLS mbedtls HINTS ENV PATH REQUIRED )
+target_link_libraries( secvarctl ${MBEDTLS} ${MBEDX509} ${MBEDCRYPTO} ${PTHREAD} )
+
+add_subdirectory( external/libstb-secvar )
+target_link_libraries( secvarctl stb-secvar-openssl )
+
+set( DEBUG_FLAGS "-O0 -g3 -Wall -Werror" )
+set( COVERAGE_FLAGS "-fprofile-arcs -ftest-coverage" )
+set( SANITIZE_FLAGS
+  "-fsanitize=address"
+  "-fsanitize=undefined"
+  "-fno-sanitize-recover=all"
+  "-fsanitize=float-divide-by-zero"
+  "-fsanitize=float-cast-overflow"
+  "-fno-sanitize=null"
+  "-fno-sanitize=alignment"
+)
+
+set( CMAKE_CONFIGURATION_TYPES "Debug" "Release" )
+set( DEFAULT_BUILD_TYPE "Debug" )
+if ( NOT CMAKE_BUILD_TYPE )
+  set( CMAKE_BUILD_TYPE ${DEFAULT_BUILD_TYPE} )
+    message( "Setting build type to default: " ${CMAKE_BUILD_TYPE} )
+endif(  )
+set( CMAKE_C_FLAGS_RELEASE "-O2 -g" )
+set( CMAKE_C_FLAGS_DEBUG   "${DEBUG_FLAGS} ${COVERAGE_FLAGS}" )
+
+option( USE_ASAN "Build with address sanitizers" OFF )
+if( USE_ASAN )
+  target_compile_options( secvarctl PRIVATE ${SANITIZE_FLAGS} )
+  target_link_options( secvarctl PRIVATE ${SANITIZE_FLAGS} )
+endif(  )
+
+install( FILES ${CMAKE_CURRENT_SOURCE_DIR}/secvarctl.1 DESTINATION ${CMAKE_INSTALL_PREFIX}/share/man/man1 )
+install( TARGETS secvarctl DESTINATION bin )

--- a/Makefile
+++ b/Makefile
@@ -158,11 +158,12 @@ secvarctl: $(BIN_DIR)/secvarctl
 secvarctl-dbg: $(BIN_DIR)/secvarctl-dbg
 debug: $(BIN_DIR)/secvarctl-dbg
 .PHONY: secvarctl secvarctl-dbg debug
+SECVAR_TOOL ?= $(BIN_DIR)/secvarctl-dbg
 
-check: secvarctl-dbg
+check: $(SECVAR_TOOL)
 	@$(MAKE) -C test MEMCHECK=$(MEMCHECK) OPENSSL=$(OPENSSL) GNUTLS=$(GNUTLS) \
 	                 HOST_BACKEND=$(HOST_BACKEND) \
-	                 SECVAR_TOOL=$(addprefix $(BIN_DIR)/,$<) \
+	                 SECVAR_TOOL=$< \
 	                 check
 
 CPPCHECK_FLAGS =  --enable=all --force -q --error-exitcode=1

--- a/backends/guest/CMakeLists.txt
+++ b/backends/guest/CMakeLists.txt
@@ -1,0 +1,18 @@
+set ( BACKEND_GUEST_SRCS 
+  guest_svc_write.c
+  guest_svc_validate.c
+  guest_svc_generate.c
+  common/validate.c
+  common/write.c
+  common/generate.c
+  common/verify.c
+  common/util.c
+  common/read.c
+  guest_svc_verify.c
+  guest_svc_read.c
+)
+
+list ( TRANSFORM BACKEND_GUEST_SRCS PREPEND ${CMAKE_CURRENT_LIST_DIR}/ )
+
+target_sources ( secvarctl PRIVATE ${BACKEND_GUEST_SRCS} )
+

--- a/backends/host/CMakeLists.txt
+++ b/backends/host/CMakeLists.txt
@@ -1,0 +1,11 @@
+set ( BACKEND_HOST_SRCS
+  host_svc_generate.c
+  host_svc_read.c
+  host_svc_validate.c
+  host_svc_verify.c
+  host_svc_write.c
+)
+
+list ( TRANSFORM BACKEND_HOST_SRCS PREPEND ${CMAKE_CURRENT_LIST_DIR}/ )
+
+target_sources ( secvarctl PRIVATE ${BACKEND_HOST_SRCS} )


### PR DESCRIPTION
The original CMake build implementation allowed for easier packaging, so for the same reason, re-implement the CMake build now that some of the architectural problems with guest/host code has been sorted out.

The goals for this implementation are as follows:
 - provide an alternative for simple builds to the Makefile
 - easier integration into packaging systems (e.g. rpmbuild)
 
 This is *NOT* intended to be feature-parity with the Makefile, as (at the moment), running tests and other pseudo-targets are much easier done with simple make rules.

Marking as a draft for now, since I'm assuming there's features missing still. Please take a look and see if there are any critical missing features.

At the moment, the following features are not implemented, and may not be for the scope of this PR:
- Crypto backend selection (same as Makefile, TBD)
- Guest/host backend selection
- Running test cases, or anything involving tests
- Pseudo build targets like `cppcheck`, `format`, etc