### PR TITLE
More build tweaks, single backend edition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,39 +8,37 @@ add_executable( secvarctl )
 
 target_sources( secvarctl PRIVATE secvarctl.c generic.c )
 
-set( INCLUDE_PATHS
+target_sources( secvarctl PRIVATE
+  # external/extraMbedtls/pkcs7.c
+  # external/extraMbedtls/pkcs7_write.c
+  # external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
+  external/skiboot/libstb/secvar/crypto/crypto-openssl.c
+  # external/skiboot/libstb/secvar/crypto/crypto-gnutls.c
+)
+
+
+target_include_directories( secvarctl BEFORE PRIVATE
   include/
   external/libstb-secvar/
   external/libstb-secvar/include/
   external/libstb-secvar/include/secvar/
-  external/skiboot/
-  external/skiboot/libstb/
-  external/skiboot/include/
-  external/extraMbedtls/include/
-  backends/host/
-  backends/guest/include/
 )
 
-target_sources( secvarctl PRIVATE
-  # external/extraMbedtls/pkcs7.c
-  # external/extraMbedtls/pkcs7_write.c
-  external/skiboot/libstb/secvar/secvar_util.c
-  # external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
-  external/skiboot/libstb/secvar/crypto/crypto-openssl.c
-  # external/skiboot/libstb/secvar/crypto/crypto-gnutls.c
-  external/skiboot/libstb/secvar/backend/edk2-compat.c
-  external/skiboot/libstb/secvar/backend/edk2-compat-process.c
-)
+target_compile_definitions( secvarctl PRIVATE SECVAR_CRYPTO_WRITE_FUNC )
 
-include( backends/host/CMakeLists.txt )
-include( backends/guest/CMakeLists.txt )
+option( HOST_BACKEND "Build with the host backend enabled" ON )
+option( GUEST_BACKEND "Build with the guest backend enabled" ON )
 
-target_include_directories( secvarctl AFTER PRIVATE ${INCLUDE_PATHS} )
-target_compile_definitions( secvarctl PRIVATE
-  SECVAR_HOST_BACKEND
-  SECVAR_GUEST_BACKEND
-  SECVAR_CRYPTO_WRITE_FUNC
-)
+if( HOST_BACKEND )
+  include( backends/host/CMakeLists.txt )
+endif()
+if( GUEST_BACKEND )
+  include( backends/guest/CMakeLists.txt )
+endif()
+if( NOT ( HOST_BACKEND OR GUEST_BACKEND) )
+  message( FATAL_ERROR "No backends are enabled, refusing to build." )
+endif()
+
 
 # OpenSSL
 target_compile_definitions( secvarctl PRIVATE SECVAR_CRYPTO_OPENSSL )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,8 +22,8 @@ set( INCLUDE_PATHS
 )
 
 target_sources( secvarctl PRIVATE
-  external/extraMbedtls/pkcs7.c
-  external/extraMbedtls/pkcs7_write.c
+  # external/extraMbedtls/pkcs7.c
+  # external/extraMbedtls/pkcs7_write.c
   external/skiboot/libstb/secvar/secvar_util.c
   # external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
   external/skiboot/libstb/secvar/crypto/crypto-openssl.c
@@ -48,10 +48,10 @@ find_package( OpenSSL REQUIRED )
 target_link_libraries( secvarctl OpenSSL::SSL )
 
 # mbedTLS
-find_library( MBEDX509 mbedx509 HINTS ENV PATH REQUIRED )
-find_library( MBEDCRYPTO mbedcrypto HINTS ENV PATH REQUIRED )
-find_library( MBEDTLS mbedtls HINTS ENV PATH REQUIRED )
-target_link_libraries( secvarctl ${MBEDTLS} ${MBEDX509} ${MBEDCRYPTO} ${PTHREAD} )
+# find_library( MBEDX509 mbedx509 HINTS ENV PATH REQUIRED )
+# find_library( MBEDCRYPTO mbedcrypto HINTS ENV PATH REQUIRED )
+# find_library( MBEDTLS mbedtls HINTS ENV PATH REQUIRED )
+# target_link_libraries( secvarctl ${MBEDTLS} ${MBEDX509} ${MBEDCRYPTO} ${PTHREAD} )
 
 add_subdirectory( external/libstb-secvar )
 target_link_libraries( secvarctl stb-secvar-openssl )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,16 +8,8 @@ add_executable( secvarctl )
 
 target_sources( secvarctl PRIVATE secvarctl.c generic.c )
 
-target_sources( secvarctl PRIVATE
-  # external/extraMbedtls/pkcs7.c
-  # external/extraMbedtls/pkcs7_write.c
-  # external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
-  external/skiboot/libstb/secvar/crypto/crypto-openssl.c
-  # external/skiboot/libstb/secvar/crypto/crypto-gnutls.c
-)
-
-
 target_include_directories( secvarctl BEFORE PRIVATE
+  ./
   include/
   external/libstb-secvar/
   external/libstb-secvar/include/
@@ -26,6 +18,7 @@ target_include_directories( secvarctl BEFORE PRIVATE
 
 target_compile_definitions( secvarctl PRIVATE SECVAR_CRYPTO_WRITE_FUNC )
 
+# Backend selection
 option( HOST_BACKEND "Build with the host backend enabled" ON )
 option( GUEST_BACKEND "Build with the guest backend enabled" ON )
 
@@ -39,17 +32,37 @@ if( NOT ( HOST_BACKEND OR GUEST_BACKEND) )
   message( FATAL_ERROR "No backends are enabled, refusing to build." )
 endif()
 
+# Crypto library selection
+set( CRYPTO "openssl" CACHE STRING "Crypto library to use" )
+set_property( CACHE CRYPTO PROPERTY STRINGS openssl mbedtls gnutls )
+get_property( CRYPTO_STRINGS CACHE CRYPTO PROPERTY STRINGS )
+if (NOT CRYPTO IN_LIST CRYPTO_STRINGS)
+  message(FATAL_ERROR "CRYPTO must be set to one of: ${CRYPTO_STRINGS}")
+endif()
+message( STATUS "Using ${CRYPTO} for crypto")
 
-# OpenSSL
-target_compile_definitions( secvarctl PRIVATE SECVAR_CRYPTO_OPENSSL )
-find_package( OpenSSL REQUIRED )
-target_link_libraries( secvarctl OpenSSL::SSL )
-
-# mbedTLS
-# find_library( MBEDX509 mbedx509 HINTS ENV PATH REQUIRED )
-# find_library( MBEDCRYPTO mbedcrypto HINTS ENV PATH REQUIRED )
-# find_library( MBEDTLS mbedtls HINTS ENV PATH REQUIRED )
-# target_link_libraries( secvarctl ${MBEDTLS} ${MBEDX509} ${MBEDCRYPTO} ${PTHREAD} )
+if( CRYPTO STREQUAL openssl )
+  target_sources( secvarctl PRIVATE external/skiboot/libstb/secvar/crypto/crypto-openssl.c )
+  target_compile_definitions( secvarctl PRIVATE SECVAR_CRYPTO_OPENSSL )
+  find_package( OpenSSL REQUIRED )
+  target_link_libraries( secvarctl OpenSSL::SSL )
+endif()
+if( CRYPTO STREQUAL mbedtls )
+  target_include_directories( secvarctl AFTER PRIVATE external/extraMbedtls/include/ )
+  target_sources( secvarctl PRIVATE
+    external/extraMbedtls/pkcs7.c
+    external/extraMbedtls/pkcs7_write.c
+    external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
+  )
+  target_compile_definitions( secvarctl PRIVATE SECVAR_CRYPTO_MBEDTLS )
+  find_library( MBEDX509 mbedx509 HINTS ENV PATH REQUIRED )
+  find_library( MBEDCRYPTO mbedcrypto HINTS ENV PATH REQUIRED )
+  find_library( MBEDTLS mbedtls HINTS ENV PATH REQUIRED )
+  target_link_libraries( secvarctl ${MBEDTLS} ${MBEDX509} ${MBEDCRYPTO} ${PTHREAD} )
+endif()
+if( CRYPTO STREQUAL gnutls )
+  message( FATAL_ERROR "gnutls is not currently supported for cmake builds" )
+endif()
 
 add_subdirectory( external/libstb-secvar )
 target_link_libraries( secvarctl stb-secvar-openssl )

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 CC ?= gcc
 _CFLAGS = -MMD -std=gnu99 -Wall -Werror
 # TODO: just put all the linker flags for now, rework the LDFLAGS settings later
-LDFLAGS = -lcrypto -lmbedtls -lmbedx509 -lmbedcrypto
+LDFLAGS = -lcrypto
 MANDIR=usr/share/man
 BIN_DIR = $(PWD)/bin
 OBJ_DIR = $(PWD)/obj
@@ -36,6 +36,8 @@ endif
 # TODO: Split libstb-secvar Makefile into includeable and runnable probably
 LIBSTB_SECVAR = external/libstb-secvar/lib/libstb-secvar-openssl.a
 
+# Initialize here, so the mbedtls option can add the bonus pkcs7 if needed
+EXTERNAL_SRCS =
 
 ifeq ($(strip $(OPENSSL)), 1)
   _LDFLAGS += -lcrypto
@@ -56,6 +58,8 @@ ifeq ($(strip $(MBEDTLS)), 1)
   CRYPTO_LIB = mbedtls
   _LDFLAGS += -lmbedtls -lmbedx509 -lmbedcrypto
   _CFLAGS += -DSECVAR_CRYPTO_MBEDTLS
+  EXTERNAL_SRCS += external/extraMbedtls/pkcs7.c \
+                   external/extraMbedtls/pkcs7_write.c
 endif
 
 
@@ -73,8 +77,7 @@ _LDFLAGS += -L./lib
 
 
 # TODO: Consider splitting this also into its own Makefile.inc?
-EXTERNAL_SRCS = external/extraMbedtls/pkcs7.c                                \
-                external/extraMbedtls/pkcs7_write.c                          \
+EXTERNAL_SRCS += \
                 external/skiboot/libstb/secvar/secvar_util.c                 \
                 external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c       \
                 external/skiboot/libstb/secvar/crypto/crypto-openssl.c       \

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ EXTERNAL_SRCS =
 ifeq ($(strip $(OPENSSL)), 1)
   _LDFLAGS += -lcrypto
   _CFLAGS += -DSECVAR_CRYPTO_OPENSSL
+  EXTERNAL_SRCS += external/skiboot/libstb/secvar/crypto/crypto-openssl.c
 endif
 
 ifeq ($(strip $(GNUTLS)), 1)
@@ -50,6 +51,7 @@ ifeq ($(strip $(GNUTLS)), 1)
   CRYPTO_LIB = gnutls
   _LDFLAGS += -lgnutls
   _CFLAGS += -DSECVAR_CRYPTO_GNUTLS
+  EXTERNAL_SRCS += external/skiboot/libstb/secvar/crypto/crypto-gnutls.c
 endif
 
 ifeq ($(strip $(MBEDTLS)), 1)
@@ -58,8 +60,10 @@ ifeq ($(strip $(MBEDTLS)), 1)
   CRYPTO_LIB = mbedtls
   _LDFLAGS += -lmbedtls -lmbedx509 -lmbedcrypto
   _CFLAGS += -DSECVAR_CRYPTO_MBEDTLS
+  INCLUDES += -I./external/extraMbedtls/include/
   EXTERNAL_SRCS += external/extraMbedtls/pkcs7.c \
-                   external/extraMbedtls/pkcs7_write.c
+                   external/extraMbedtls/pkcs7_write.c \
+                   external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
 endif
 
 
@@ -74,16 +78,6 @@ endif
 
 
 _LDFLAGS += -L./lib
-
-
-# TODO: Consider splitting this also into its own Makefile.inc?
-EXTERNAL_SRCS += \
-                external/skiboot/libstb/secvar/secvar_util.c                 \
-                external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c       \
-                external/skiboot/libstb/secvar/crypto/crypto-openssl.c       \
-                external/skiboot/libstb/secvar/crypto/crypto-gnutls.c        \
-                external/skiboot/libstb/secvar/backend/edk2-compat.c         \
-                external/skiboot/libstb/secvar/backend/edk2-compat-process.c
 
 MAIN_SRCS = generic.c \
             secvarctl.c

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,6 @@ ifeq ($(strip $(CRYPTO_READ_ONLY)), 0)
   _CFLAGS += -DSECVAR_CRYPTO_WRITE_FUNC
 endif
 
-# TODO: Split libstb-secvar Makefile into includeable and runnable probably
-LIBSTB_SECVAR = external/libstb-secvar/lib/libstb-secvar-openssl.a
-# currently required for libstb-secvar, should be dependent on crypto library choice
-LDFLAGS = -lcrypto
-
 # Initialize here, so the mbedtls option can add the bonus pkcs7 if needed
 EXTERNAL_SRCS =
 
@@ -61,6 +56,14 @@ ifeq ($(CRYPTO), mbedtls)
                    external/extraMbedtls/pkcs7_write.c \
                    external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
 endif
+
+
+LIBSTB_SECVAR_ROOT ?= external/libstb-secvar/
+# LIBSTB_SECVAR_ARCHIVE = libstb-secvar-$(CRYPTO).a # TODO: uncomment when libstb-secvar supports other libraries
+LIBSTB_SECVAR_ARCHIVE = libstb-secvar-openssl.a
+LIBSTB_SECVAR = $(LIBSTB_SECVAR_ROOT)/lib/$(LIBSTB_SECVAR_ARCHIVE)
+# NOTE: currently required for libstb-secvar, should be dependent on crypto library choice
+LDFLAGS = -lcrypto
 
 
 #use STATIC=1 for static build
@@ -134,7 +137,7 @@ $(BIN_DIR)/secvarctl-dbg: $(OBJDBG) $(LIBSTB_SECVAR)
 	$(CC) $(_CFLAGS) -g $^ $(STATICFLAG) $(SANITIZE_FLAGS) -fprofile-arcs -ftest-coverage -o $@ $(_LDFLAGS)
 
 $(LIBSTB_SECVAR):
-	$(MAKE) CFLAGS=-DSECVAR_CRYPTO_WRITE_FUNC -C external/libstb-secvar lib/libstb-secvar-openssl.a
+	$(MAKE) CFLAGS=-DSECVAR_CRYPTO_WRITE_FUNC -C $(LIBSTB_SECVAR_ROOT) lib/$(LIBSTB_SECVAR_ARCHIVE)
 
 
 secvarctl: $(BIN_DIR)/secvarctl

--- a/backends/guest/CMakeLists.txt
+++ b/backends/guest/CMakeLists.txt
@@ -12,7 +12,12 @@ set ( BACKEND_GUEST_SRCS
   guest_svc_read.c
 )
 
+target_include_directories ( secvarctl BEFORE PRIVATE
+  backends/guest/include/
+)
+
 list ( TRANSFORM BACKEND_GUEST_SRCS PREPEND ${CMAKE_CURRENT_LIST_DIR}/ )
 
 target_sources ( secvarctl PRIVATE ${BACKEND_GUEST_SRCS} )
 
+target_compile_definitions( secvarctl PRIVATE SECVAR_GUEST_BACKEND )

--- a/backends/guest/Makefile.inc
+++ b/backends/guest/Makefile.inc
@@ -1,3 +1,7 @@
+INCLUDES += -I./backends/guest/include
+
+_CFLAGS += -DSECVAR_GUEST_BACKEND
+
 GUEST_SRCS = guest_svc_write.c \
              guest_svc_validate.c \
              guest_svc_generate.c \
@@ -9,3 +13,5 @@ GUEST_SRCS = guest_svc_write.c \
              common/read.c \
              guest_svc_verify.c \
              guest_svc_read.c
+
+MAIN_SRCS += $(addprefix backends/guest/,$(GUEST_SRCS))

--- a/backends/host/CMakeLists.txt
+++ b/backends/host/CMakeLists.txt
@@ -6,6 +6,22 @@ set ( BACKEND_HOST_SRCS
   host_svc_write.c
 )
 
+target_include_directories ( secvarctl AFTER PRIVATE
+  external/skiboot/
+  external/skiboot/libstb/
+  external/skiboot/include/
+  backends/host/
+)
+
 list ( TRANSFORM BACKEND_HOST_SRCS PREPEND ${CMAKE_CURRENT_LIST_DIR}/ )
 
 target_sources ( secvarctl PRIVATE ${BACKEND_HOST_SRCS} )
+
+# External dependencies
+target_sources ( secvarctl PRIVATE
+  external/skiboot/libstb/secvar/secvar_util.c
+  external/skiboot/libstb/secvar/backend/edk2-compat.c
+  external/skiboot/libstb/secvar/backend/edk2-compat-process.c
+)
+
+target_compile_definitions ( secvarctl PRIVATE SECVAR_HOST_BACKEND )

--- a/backends/host/Makefile.inc
+++ b/backends/host/Makefile.inc
@@ -1,5 +1,15 @@
+INCLUDES += -I./external/skiboot               \
+            -I./external/skiboot/libstb        \
+            -I./external/skiboot/include       \
+            -I./external/extraMbedtls/include/ \
+            -I./backends/host
+
+_CFLAGS += -DSECVAR_HOST_BACKEND
+
 HOST_SRCS = host_svc_generate.c \
             host_svc_read.c \
             host_svc_validate.c \
             host_svc_verify.c \
             host_svc_write.c
+
+MAIN_SRCS += $(addprefix backends/host/,$(HOST_SRCS))

--- a/backends/host/Makefile.inc
+++ b/backends/host/Makefile.inc
@@ -1,7 +1,6 @@
 INCLUDES += -I./external/skiboot               \
             -I./external/skiboot/libstb        \
             -I./external/skiboot/include       \
-            -I./external/extraMbedtls/include/ \
             -I./backends/host
 
 _CFLAGS += -DSECVAR_HOST_BACKEND
@@ -13,3 +12,8 @@ HOST_SRCS = host_svc_generate.c \
             host_svc_write.c
 
 MAIN_SRCS += $(addprefix backends/host/,$(HOST_SRCS))
+
+EXTERNAL_SRCS += \
+                 external/skiboot/libstb/secvar/secvar_util.c                 \
+                 external/skiboot/libstb/secvar/backend/edk2-compat.c         \
+                 external/skiboot/libstb/secvar/backend/edk2-compat-process.c


### PR DESCRIPTION
This PR is not based on #49 , and may have minor conflicts. Since this one is much smaller, consider reviewing and merging this one first.

This PR reworks the build system to support selecting which backend to use, and which crypto library to link against.

Major changes:
 - split backend-specific dependencies into their respective makefile/cmake include files
 - remove unneeded files for a build, such as the extra mbedtls pkcs7
 - start the process of splitting the crypto implementations, though that will really depend on the forthcoming crypto library rework
 - (Makefile): replace the `OPENSSL=1`, `MBEDTLS=0`, etc options with a single `CRYPTO=openssl` variable
 
 ---

## Future work

Now that single backends have been implemented, and crypto library selection "in place": this is a good opportunity to really flex the CI. I will be spinning up a new branch to rework the host/guest tests to only run if the built binary supports host/guest, and then create a test matrix for guest-only, host-only, both -- for each crypto library. Actions will be split from cmake build and makefile build independently.