### PR TITLE
Improve single-backend builds, allow for testing single-backends, update CI

### DIFF
--- a/.github/workflows/CI_formatting.yml
+++ b/.github/workflows/CI_formatting.yml
@@ -1,9 +1,9 @@
-name: Test Source Code Formatting
+name: Format Check and Static Analysis
 
 on: ['push', 'pull_request']
 
 jobs:
-  build:
+  formatcheck:
 
     runs-on: ubuntu-latest
 
@@ -15,3 +15,18 @@ jobs:
 
     - name: test if formatting is appropriate
       run: make formatcheck
+
+  cppcheck:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: install cppcheck
+      run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+    - name: run cppcheck
+      run: make cppcheck

--- a/.github/workflows/x86_CI.yml
+++ b/.github/workflows/x86_CI.yml
@@ -3,7 +3,7 @@ name: x86 Make CI
 on: ['push', 'pull_request']
 
 jobs:
-  build:
+  makefile:
 
     runs-on: ubuntu-latest
 
@@ -13,18 +13,44 @@ jobs:
         submodules: 'recursive'
 
     - name: install openssl and valgrind for running test script
-      run:  sudo apt-get update && sudo apt-get install -y openssl valgrind libssl-dev libmbedtls-dev cppcheck cmake
-
-    - name: run cppcheck
-      run: make cppcheck
+      run:  sudo apt-get update && sudo apt-get install -y openssl libssl-dev libmbedtls-dev
 
     - name: run test cases
       run: make check
 
-    - name: run and test cmake builds
-      run: |
-        cmake -Bbuild . -DUSE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug
-        cmake --build build
-        make check SECVAR_TOOL=$(pwd)/build/secvarctl
-        
+  cmake:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: install openssl and valgrind for running test script
+      run:  sudo apt-get update && sudo apt-get install -y openssl libssl-dev libmbedtls-dev cmake
+
+    - name: generate cmake build
+      run: cmake -Bbuild . -DUSE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug
+
+    - name: run cmake build
+      run: cmake --build build
+
+    - name: run test cases
+      run: make check SECVAR_TOOL=$(pwd)/build/secvarctl
+
+  cppcheck:
   
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+
+    - name: install cppcheck
+      run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+    - name: run cppcheck
+      run: make cppcheck
+

--- a/.github/workflows/x86_CI.yml
+++ b/.github/workflows/x86_CI.yml
@@ -4,6 +4,9 @@ on: ['push', 'pull_request']
 
 jobs:
   makefile:
+    strategy:
+      matrix:
+        backend: ["", "GUEST_BACKEND=0", "HOST_BACKEND=0"]
 
     runs-on: ubuntu-latest
 
@@ -16,9 +19,12 @@ jobs:
       run:  sudo apt-get update && sudo apt-get install -y openssl libssl-dev libmbedtls-dev
 
     - name: run test cases
-      run: make check
+      run: make ${{ matrix.backend }} check
 
   cmake:
+    strategy:
+      matrix:
+        backend: ["", "-DGUEST_BACKEND=0", "-DHOST_BACKEND=0"]
 
     runs-on: ubuntu-latest
 
@@ -31,7 +37,7 @@ jobs:
       run:  sudo apt-get update && sudo apt-get install -y openssl libssl-dev libmbedtls-dev cmake
 
     - name: generate cmake build
-      run: cmake -Bbuild . -DUSE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug
+      run: cmake -Bbuild . -DUSE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug ${{ matrix.backend }}
 
     - name: run cmake build
       run: cmake --build build

--- a/.github/workflows/x86_CI.yml
+++ b/.github/workflows/x86_CI.yml
@@ -38,19 +38,3 @@ jobs:
 
     - name: run test cases
       run: make check SECVAR_TOOL=$(pwd)/build/secvarctl
-
-  cppcheck:
-  
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
-
-    - name: install cppcheck
-      run: sudo apt-get update && sudo apt-get install -y cppcheck
-
-    - name: run cppcheck
-      run: make cppcheck
-

--- a/backends/guest/include/guest_svc_backend.h
+++ b/backends/guest/include/guest_svc_backend.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include "generic.h"
 
+#define GUEST_BACKEND_FORMAT "ibm,plpks-sb-v1"
+
 /*
  * called from main()
  * handles argument parsing for validate command

--- a/backends/host/host_svc_backend.h
+++ b/backends/host/host_svc_backend.h
@@ -21,6 +21,8 @@
 #define SECVARPATH "/sys/firmware/secvar/vars/"
 #endif
 
+#define HOST_BACKEND_FORMAT "ibm,edk2-compat-v1"
+
 #define variables                                                                                  \
 	(char *[])                                                                                 \
 	{                                                                                          \

--- a/include/secvarctl.h
+++ b/include/secvarctl.h
@@ -9,10 +9,8 @@
 #include "err.h"
 #include "prlog.h"
 
-enum backends { UNKNOWN_BACKEND = 0, BACKEND_FOUND };
-
 struct backend {
-	char name[32];
+	char format[32];
 	size_t countCmds;
 	struct command *commands;
 };

--- a/test/common.py
+++ b/test/common.py
@@ -57,3 +57,8 @@ class SecvarctlTest(unittest.TestCase):
         self.command(
             ["cp", "-a", f"{self.test_data_dir}/goldenKeys/.", f"{self.test_env_dir}/"]
         )
+
+    def checkBackend(self, backend):
+        result = self.command([SECTOOLS, "-m", backend, "-h"])
+        if not bool(result):
+            raise unittest.SkipTest

--- a/test/guest_tests.py
+++ b/test/guest_tests.py
@@ -158,6 +158,7 @@ class Test(SecvarctlTest):
     test_data_dir = f"{DATAPATH}"
 
     def setUp(self):
+        self.checkBackend("guest")
         self.setupTestEnvironment()
         self.command(["mkdir", "-p", gen_dir])
 

--- a/test/host_generate_tests.py
+++ b/test/host_generate_tests.py
@@ -85,6 +85,7 @@ class Test(SecvarctlTest):
     test_data_dir = f"{DATAPATH}"
 
     def setUp(self):
+        self.checkBackend("host")
         self.setupTestEnvironment()
         self.command(["mkdir", "-p", "./generatedTestData"])
         self.command(["mkdir", "-p", "./generatedTestData/brokenFiles"])

--- a/test/host_tests.py
+++ b/test/host_tests.py
@@ -165,6 +165,7 @@ class Test(SecvarctlTest):
     test_data_dir = f"{DATAPATH}"
 
     def setUp(self):
+        self.checkBackend("host")
         self.setupTestEnvironment()
 
     def test_secvarctl_basic(self):


### PR DESCRIPTION
Opening this PR so I don't forget/lose the branch, but it's lower priority.

---
This PR changes three major components:
 - rewrite secvarctl backend selection logic, to make it easier to manage disabling certain backends
 - have tests skip if the target backend is not supported
 - use a matrix strategy to additionally test single-backend builds
 
 ---
 
There is one major side effect to the `secvarctl.c` rewrite: the `-m` flag is now mandatory when running on a non-secure boot enabled POWER system (i.e. x86). This is largely because the tool should not make assumptions on what backend to use, nor should it "default" to one, which may lead to unexpected behavior.

Currently, the mode flag is still required for a single-backend build. Personally, I'm of the opinion that it should be required even in a single-backend build, as it enforces the same "no-assumption" rule as above: if you are handed a `secvarctl` binary, it is unclear which backends it supports. Therefore, especially if running on a foreign architecture, it should not just happily execute without enforcing that the intended backend is even supported.

As a side note: there should probably be a better way to inspect a binary for what backends it supports. There should probably be something mentioned in the usage information on what backends are enabled. In addition, maybe there should be a flag that returns the enabled backends -- would be useful in particular for scripts to inspect which backends are supported.