### PR TITLE
guest/generate: change --append option to be a boolean based on presence

### DIFF
--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -477,12 +477,7 @@ static int parse_options(int key, char *arg, struct argp_state *state)
 		}
 		break;
 	case 'a':
-		args->append_flag = strtol(arg, NULL, 0);
-		if (args->append_flag < 0 || args->append_flag > 1) {
-			prlog(PR_ERR, "ERROR: append flag accept 0 or 1 only but it is %d\n",
-			      args->append_flag);
-			rc = ARG_PARSE_FAIL;
-		}
+		args->append_flag = 1;
 		break;
 	case ARGP_KEY_ARG:
 		/* check if reset key is desired */
@@ -586,8 +581,7 @@ int guest_generate_command(int argc, char *argv[])
 		  "info/ranges" },
 		{ "force", 'f', 0, 0,
 		  "does not do prevalidation on the input file, assumes format is correct" },
-		{ "append flag", 'a', "APPEND_FLAG", 0,
-		  "set append flag, used when generating auth file" },
+		{ "append", 'a', 0, 0, "set append flag, used when generating auth file" },
 		{ 0, 'i', "FILE", OPTION_HIDDEN, "input file" },
 		{ 0, 'o', "FILE", OPTION_HIDDEN, "output file" },
 		{ "help", '?', 0, 0, "Give this help list", 1 },

--- a/guest-usage.md
+++ b/guest-usage.md
@@ -172,7 +172,7 @@ auth file data format is:
 		--usage
 		--help
 		-v , verbose, gives process info
-		-a <append flag>, used when generating an auth file and By default, append flag is set to 0. it accept only 0 or 1. 0 for replace update and 1 for append update
+		-a , use when generating and auth file to set the append flag
 		-n <varName> , name of secure boot variable, used when generating an auth file, PKCS7, or hash file
 		-f force generation, skips validation of input file, assumes format to be correct
 		-t <time> , where <time> is of the format described below. creates a custom timestamp used when generating an auth or PKCS7 file, if not given then current time is used, all times are in UTC


### PR DESCRIPTION
Fixes #65.

Currently, the -a --append option accepts a string to be parsed into an integer, either 0 or 1. This integer is then used to set a boolean append flag.

Avoid parsing strings at all by having the boolean append flag be set to 1 if -a/--append exists, otherwise default to 0.

NOTE: This does introduce a change in the command line API.

---

This one is a slightly more invasive change, but I think the removal of needless string parsing is better for overall safety. Please let me know if you disagree with this approach.