### PR TITLE
guest/generate: reword error message for disallowing PK appends

### DIFF
--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -510,8 +510,6 @@ static int parse_options(int key, char *arg, struct argp_state *state)
 			      "option\n");
 		else if (args->output_file == NULL)
 			prlog(PR_ERR, "ERROR: no output file given, see usage below...\n");
-		else if (args->append_flag > 0 && strcmp(PK_VARIABLE, args->variable_name) == 0)
-			prlog(PR_ERR, "ERROR: append flag should be 0 for PK\n");
 		else
 			break;
 		argp_usage(state);
@@ -521,6 +519,12 @@ static int parse_options(int key, char *arg, struct argp_state *state)
 
 	if (rc)
 		prlog(PR_ERR, "failed during argument parsing\n");
+
+	// Special case, filter out appends on PK
+	if (args->append_flag > 0 && strcmp(PK_VARIABLE, args->variable_name) == 0) {
+		prlog(PR_ERR, "ERROR: PK does not support the append flag\n");
+		rc = ARG_PARSE_FAIL;
+	}
 
 	return rc;
 }


### PR DESCRIPTION
Addresses #65 

There can only be one PK, therefore the PK cannot be appended to. However, the current error message is not clear, and references the older method of setting the flag. Furthermore, this error is handled in the same way as an invalid argument parse which leads to the whole usage information being printed, which makes finding the error message difficult.

This commit rewords the error message to be a little more clear, and moves the special case check for PK appends outside of the rest of the argument validation logic, thus avoiding the extra usage output.