### PR TITLE
Type Usage Overhaul + Assorted Static Analysis Fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,8 +155,9 @@ check: $(SECVAR_TOOL)
 
 CPPCHECK_FLAGS =  --enable=all --force -q --error-exitcode=1
 CPPCHECK_FLAGS += --suppress=missingIncludeSystem
-CPPCHECK_FLAGS += --suppress=unusedFunction       # false positive on validateTS
-CPPCHECK_FLAGS += --suppress=internalAstError     # false positive on ccan/list_for_each
+CPPCHECK_FLAGS += --suppress=unusedFunction             # false positive on validateTS
+CPPCHECK_FLAGS += --suppress=internalAstError           # false positive on ccan/list_for_each
+CPPCHECK_FLAGS += --suppress=*:external/skiboot/ccan/*  # skip checking headers in external code
 cppcheck:
 	cppcheck $(CPPCHECK_FLAGS) $(INCLUDES) $(MAIN_SRCS)
 

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,7 @@ CPPCHECK_FLAGS += --suppress=missingIncludeSystem
 CPPCHECK_FLAGS += --suppress=unusedFunction             # false positive on validateTS
 CPPCHECK_FLAGS += --suppress=internalAstError           # false positive on ccan/list_for_each
 CPPCHECK_FLAGS += --suppress=*:external/skiboot/ccan/*  # skip checking headers in external code
+CPPCHECK_FLAGS += --suppress=unmatchedSuppression       # stop cppcheck from complaining if suppressions aren't hit
 cppcheck:
 	cppcheck $(CPPCHECK_FLAGS) $(INCLUDES) $(MAIN_SRCS)
 

--- a/backends/guest/common/generate.c
+++ b/backends/guest/common/generate.c
@@ -21,7 +21,7 @@
  * @param timestamp , a pointer to an allocated timestamp_t to be filled with data
  * @param current_time , the current timestamp
  */
-static void convert_timestamp(timestamp_t *timestamp, struct tm *current_time)
+static void convert_timestamp(timestamp_t *timestamp, const struct tm *current_time)
 {
 	timestamp->year = 1900 + current_time->tm_year;
 	timestamp->month = current_time->tm_mon + 1;

--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -196,7 +196,6 @@ int print_esl_buffer(const uint8_t *buffer, size_t buffer_size, const char *var_
 	int rc;
 	size_t esl_data_size = 0;
 	size_t esl_count = 0;
-	enum signature_type sig_type;
 
 	union {
 		const uint8_t *raw;
@@ -211,6 +210,7 @@ int print_esl_buffer(const uint8_t *buffer, size_t buffer_size, const char *var_
 	}
 
 	while (curr_esl.esl != NULL) {
+		enum signature_type sig_type;
 		esl_count++;
 		printf("ESL %zu:\n", esl_count);
 		print_esl_info(curr_esl.esl);

--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -162,11 +162,11 @@ static int print_esd_from_esl_buffer(const uint8_t *esl, size_t esl_size,
 			break;
 		case ST_SBAT:
 			printf("\tData: ");
-			print_raw((char *)curr_esd.raw, esd_data_size);
+			print_raw(curr_esd.raw, esd_data_size);
 			break;
 		case ST_DELETE:
 			printf("\tDELETE-MSG: ");
-			print_raw((char *)curr_esd.raw, esd_data_size);
+			print_raw(curr_esd.raw, esd_data_size);
 			break;
 		default:
 			prlog(PR_ERR, "ERROR: unknown signature type = %d\n", sig_type);

--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -41,7 +41,7 @@ int extract_esl_cert(const uint8_t *buf, const size_t buflen, uint8_t **cert)
 {
 	size_t sig_data_offset;
 	size_t size;
-	sv_esl_t *list = extract_esl_signature_list(buf, buflen);
+	const sv_esl_t *list = extract_esl_signature_list(buf, buflen);
 
 	if (!list || cert == NULL)
 		return -1;

--- a/backends/guest/common/util.c
+++ b/backends/guest/common/util.c
@@ -12,26 +12,19 @@
 #include "pseries.h"
 #include "common/util.h"
 
-#define X509_TYPE (uint8_t *)"X509"
-#define RSA2048_TYPE (uint8_t *)"RSA2048"
-#define PKCS7_TYPE (uint8_t *)"PKCS7"
-#define SBAT_TYPE (uint8_t *)"SBAT"
-#define DELETE_TYPE (uint8_t *)"DELETE-ALL"
-#define UNKNOWN_TYPE (uint8_t *)"UNKNOWN"
-
 // clang-format off
 const struct signature_type_info signature_type_list[] = {
-	[ST_X509]             = { .name = "X509",       .uuid = &PKS_CERT_X509_GUID },
-	[ST_RSA2048]          = { .name = "RSA2048",    .uuid = &PKS_CERT_RSA2048_GUID },
-	[ST_PKCS7]            = { .name = "PKCS7",      .uuid = &AUTH_CERT_TYPE_PKCS7_GUID },
-	[ST_SBAT]             = { .name = "SBAT",       .uuid = &PKS_CERT_SBAT_GUID },
-	[ST_DELETE]           = { .name = "DELETE-ALL", .uuid = &PKS_CERT_DELETE_GUID },
-	[ST_HASH_SHA1]        = { .name = "SHA1",       .uuid = &PKS_CERT_SHA1_GUID,	.crypto_id = CRYPTO_MD_SHA1,	.size = 20},
-	[ST_HASH_SHA224]      = { .name = "SHA224",     .uuid = &PKS_CERT_SHA224_GUID,	.crypto_id = CRYPTO_MD_SHA224,	.size = 28 },
-	[ST_HASH_SHA256]      = { .name = "SHA256",     .uuid = &PKS_CERT_SHA256_GUID,	.crypto_id = CRYPTO_MD_SHA256,	.size = 32 },
-	[ST_HASH_SHA384]      = { .name = "SHA384",     .uuid = &PKS_CERT_SHA384_GUID,	.crypto_id = CRYPTO_MD_SHA384,	.size = 48 },
-	[ST_HASH_SHA512]      = { .name = "SHA512",     .uuid = &PKS_CERT_SHA512_GUID,	.crypto_id = CRYPTO_MD_SHA512,	.size = 64 },
-	[ST_UNKNOWN]          = { .name = "UNKNOWN",    .uuid = NULL},
+	[ST_X509]        = { .name = "X509",       .uuid = &PKS_CERT_X509_GUID        },
+	[ST_RSA2048]     = { .name = "RSA2048",    .uuid = &PKS_CERT_RSA2048_GUID     },
+	[ST_PKCS7]       = { .name = "PKCS7",      .uuid = &AUTH_CERT_TYPE_PKCS7_GUID },
+	[ST_SBAT]        = { .name = "SBAT",       .uuid = &PKS_CERT_SBAT_GUID        },
+	[ST_DELETE]      = { .name = "DELETE-ALL", .uuid = &PKS_CERT_DELETE_GUID      },
+	[ST_HASH_SHA1]   = { .name = "SHA1",       .uuid = &PKS_CERT_SHA1_GUID,   .crypto_id = CRYPTO_MD_SHA1,   .size = 20 },
+	[ST_HASH_SHA224] = { .name = "SHA224",     .uuid = &PKS_CERT_SHA224_GUID, .crypto_id = CRYPTO_MD_SHA224, .size = 28 },
+	[ST_HASH_SHA256] = { .name = "SHA256",     .uuid = &PKS_CERT_SHA256_GUID, .crypto_id = CRYPTO_MD_SHA256, .size = 32 },
+	[ST_HASH_SHA384] = { .name = "SHA384",     .uuid = &PKS_CERT_SHA384_GUID, .crypto_id = CRYPTO_MD_SHA384, .size = 48 },
+	[ST_HASH_SHA512] = { .name = "SHA512",     .uuid = &PKS_CERT_SHA512_GUID, .crypto_id = CRYPTO_MD_SHA512, .size = 64 },
+	[ST_UNKNOWN]     = { .name = "UNKNOWN",    .uuid = NULL},
 };
 // clang-format on
 

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -185,12 +185,12 @@ static int validate_single_esl(const uint8_t *esl_data, size_t esl_data_size, si
 
 		if (verbose >= PR_INFO) {
 			prlog(PR_INFO, "\tSBAT: ");
-			print_raw((char *)cert, cert_size);
+			print_raw(cert, cert_size);
 		}
 	} else if (is_delete(sig_type)) {
 		if (verbose >= PR_INFO) {
 			prlog(PR_INFO, "\tDELETE-MSG: ");
-			print_raw((char *)cert, cert_size);
+			print_raw(cert, cert_size);
 		}
 		rc = SUCCESS;
 	} else {

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -156,7 +156,7 @@ static int get_current_esl(const struct verify_args *args, const char *update_va
 {
 	int i = 0, rc = SUCCESS;
 	size_t len = 0;
-	char *esl_data = "/data";
+	const char *esl_data = "/data";
 	char *esl_data_path = NULL;
 	uint8_t *current_esl = *current_esl_data;
 	size_t current_esl_size = 0;
@@ -332,7 +332,8 @@ static int get_pk_and_kek_from_update_var(const struct verify_args *args, uint8_
 					  size_t *kek_esl_data_size)
 {
 	int i = 0, rc = SUCCESS;
-	uint8_t *current_esl_data = NULL, *auth_data = NULL;
+	const uint8_t *current_esl_data = NULL;
+	uint8_t *auth_data = NULL;
 	size_t current_esl_data_size = 0, auth_data_size = 0;
 	bool append_update;
 
@@ -379,7 +380,7 @@ static int get_pk_and_kek_from_update_var(const struct verify_args *args, uint8_
  * extract the PK and KEK from update or current or path variables and
  * verify the all variables using PK or KEK
  */
-int verify_variables(struct verify_args *args)
+int verify_variables(const struct verify_args *args)
 {
 	int rc = SUCCESS;
 	uint8_t *pk_esl_data = NULL, *kek_esl_data = NULL;

--- a/backends/guest/common/write.c
+++ b/backends/guest/common/write.c
@@ -60,18 +60,17 @@ int write_to_variable(const char *path, const char *variable_name, const uint8_t
  * @param force, 1 for no validation of auth, 0 for validate
  * @return error if variable given is unknown, or issue validating or writing
  */
-int write_variable(const uint8_t *variable_name, const uint8_t *auth_file, const uint8_t *path,
-		   int force)
+int write_variable(const char *variable_name, const char *auth_file, const char *path, int force)
 {
 	int rc;
 	uint8_t *buffer = NULL;
 	size_t buffer_size;
 
 	if (!path) {
-		path = (uint8_t *)SECVARPATH;
+		path = SECVARPATH;
 	}
 
-	buffer = (uint8_t *)get_data_from_file((char *)auth_file, SIZE_MAX, &buffer_size);
+	buffer = (uint8_t *)get_data_from_file(auth_file, SIZE_MAX, &buffer_size);
 	if (buffer == NULL)
 		return INVALID_FILE;
 
@@ -84,7 +83,7 @@ int write_variable(const uint8_t *variable_name, const uint8_t *auth_file, const
 		}
 	}
 
-	rc = write_to_variable((char *)path, (char *)variable_name, buffer, buffer_size);
+	rc = write_to_variable(path, variable_name, buffer, buffer_size);
 	if (rc != SUCCESS)
 		prlog(PR_ERR, "ERROR: issue writing to file: %s\n", strerror(errno));
 

--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -542,7 +542,7 @@ int guest_generate_command(int argc, char *argv[])
 	int rc = 0;
 	size_t out_buffer_size = 0, size = 0;
 	enum signature_type hash_function;
-	unsigned char *buffer = NULL, *out_buffer = NULL;
+	uint8_t *buffer = NULL, *out_buffer = NULL;
 	struct generate_args args = { 0 };
 
 	memset(&args, 0x00, sizeof(struct generate_args));
@@ -673,7 +673,7 @@ int guest_generate_command(int argc, char *argv[])
 		size = 0;
 	else {
 		/* get data from input file */
-		buffer = (unsigned char *)get_data_from_file(args.input_file, SIZE_MAX, &size);
+		buffer = get_data_from_file(args.input_file, SIZE_MAX, &size);
 		if (buffer == NULL) {
 			prlog(PR_ERR, "ERROR: could not find data in file %s\n", args.input_file);
 			rc = INVALID_FILE;
@@ -699,7 +699,7 @@ int guest_generate_command(int argc, char *argv[])
 
 	prlog(PR_INFO, "writing %zu bytes to %s\n", out_buffer_size, args.output_file);
 	/* write data to new file */
-	rc = create_file(args.output_file, (char *)out_buffer, out_buffer_size);
+	rc = create_file(args.output_file, out_buffer, out_buffer_size);
 	if (rc) {
 		prlog(PR_ERR, "ERROR: could not write new data to output file %s\n",
 		      args.output_file);

--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -521,7 +521,8 @@ static int parse_options(int key, char *arg, struct argp_state *state)
 		prlog(PR_ERR, "failed during argument parsing\n");
 
 	// Special case, filter out appends on PK
-	if (args->append_flag > 0 && strcmp(PK_VARIABLE, args->variable_name) == 0) {
+	if (args->append_flag > 0 && args->variable_name != NULL &&
+	    strcmp(PK_VARIABLE, args->variable_name) == 0) {
 		prlog(PR_ERR, "ERROR: PK does not support the append flag\n");
 		rc = ARG_PARSE_FAIL;
 	}

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -91,7 +91,7 @@ static int read_cert(const uint8_t *cert_data, const size_t cert_data_len, const
 	crypto_x509_t *x509;
 
 	if (is_print_raw) {
-		print_raw((char *)cert_data, cert_data_len);
+		print_raw(cert_data, cert_data_len);
 		return rc;
 	}
 
@@ -149,7 +149,7 @@ static int read_esl(const uint8_t *esl_data, const size_t esl_data_len, const in
 	int rc = SUCCESS;
 
 	if (is_print_raw) {
-		print_raw((char *)esl_data, esl_data_len);
+		print_raw(esl_data, esl_data_len);
 		return rc;
 	}
 
@@ -182,7 +182,7 @@ static int read_auth(const uint8_t *auth_data, size_t auth_data_len, const int i
 	}
 
 	if (is_print_raw) {
-		print_raw((char *)auth_data, auth_data_len);
+		print_raw(auth_data, auth_data_len);
 		return rc;
 	}
 
@@ -260,7 +260,7 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 		rc = variable_from_path(variable_path, &esl_data, &esl_data_size);
 		if (rc == SUCCESS) {
 			if (is_print_raw || esl_data_size == DEFAULT_PK_LEN)
-				print_raw((char *)esl_data, esl_data_size);
+				print_raw(esl_data, esl_data_size);
 			else if (esl_data_size >= TIMESTAMP_LEN)
 				rc = print_esl_buffer(esl_data + TIMESTAMP_LEN,
 						      esl_data_size - TIMESTAMP_LEN, variable_name);
@@ -277,8 +277,7 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 			free(variable_path);
 	} else {
 		for (int i = 0; i < defined_sb_variable_len; i++) {
-			rc = get_variable_path(path, (char *)defined_sb_variables[i],
-					       &variable_path);
+			rc = get_variable_path(path, defined_sb_variables[i], &variable_path);
 			if (rc != SUCCESS)
 				return rc;
 
@@ -288,7 +287,7 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 				if (is_print_raw ||
 				    (esl_data_size == DEFAULT_PK_LEN &&
 				     strcmp(defined_sb_variables[i], PK_VARIABLE) == 0))
-					print_raw((char *)esl_data, esl_data_size);
+					print_raw(esl_data, esl_data_size);
 				else if (esl_data_size >= TIMESTAMP_LEN)
 					rc = print_esl_buffer(esl_data + TIMESTAMP_LEN,
 							      esl_data_size - TIMESTAMP_LEN,

--- a/backends/guest/guest_svc_validate.c
+++ b/backends/guest/guest_svc_validate.c
@@ -78,7 +78,7 @@ static int parse_options(int key, char *arg, struct argp_state *state)
  */
 int guest_validation_command(int argc, char *argv[])
 {
-	unsigned char *buff = NULL;
+	uint8_t *buff = NULL;
 	size_t size;
 	int rc;
 	struct validate_args args = {
@@ -115,7 +115,7 @@ int guest_validation_command(int argc, char *argv[])
 	if (rc || args.help_flag)
 		return rc;
 
-	buff = (unsigned char *)get_data_from_file(args.input_file, SIZE_MAX, &size);
+	buff = get_data_from_file(args.input_file, SIZE_MAX, &size);
 	if (!buff) {
 		prlog(PR_ERR, "ERROR: failed to get data from %s\n", args.input_file);
 		return INVALID_FILE;

--- a/backends/guest/guest_svc_write.c
+++ b/backends/guest/guest_svc_write.c
@@ -111,8 +111,7 @@ int guest_write_command(int argc, char *argv[])
 	if (rc || args.help_flag)
 		goto out;
 
-	rc = write_variable((uint8_t *)args.variable_name, (uint8_t *)args.input_file,
-			    (uint8_t *)args.path, args.input_valid);
+	rc = write_variable(args.variable_name, args.input_file, args.path, args.input_valid);
 
 out:
 	if (!args.help_flag)

--- a/backends/guest/include/common/util.h
+++ b/backends/guest/include/common/util.h
@@ -11,11 +11,11 @@
 #define DEFAULT_PK_LEN 31
 #define APPEND_HEADER_LEN 8
 #define TIMESTAMP_LEN 8
-#define PK_VARIABLE (char *)"PK"
+#define PK_VARIABLE "PK"
 #define PK_LEN 2
-#define KEK_VARIABLE (char *)"KEK"
+#define KEK_VARIABLE "KEK"
 #define KEK_LEN 3
-#define SBAT_VARIABLE (char *)"sbat"
+#define SBAT_VARIABLE "sbat"
 
 static const uuid_t PKS_CERT_DELETE_GUID = { { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 					       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } };

--- a/backends/guest/include/common/verify.h
+++ b/backends/guest/include/common/verify.h
@@ -20,7 +20,7 @@ struct verify_args {
 	const char **current_variable;
 };
 
-int verify_variables(struct verify_args *args);
+int verify_variables(const struct verify_args *args);
 
 int parse_variable_arguments(struct argp_state *state, const char ***variables, int *variable_size);
 

--- a/backends/guest/include/common/write.h
+++ b/backends/guest/include/common/write.h
@@ -26,8 +26,7 @@ struct write_args {
  * @param force, 1 for no validation of auth, 0 for validate
  * @return error if variable given is unknown, or issue validating or writing
  */
-int write_variable(const uint8_t *variable_name, const uint8_t *auth_file, const uint8_t *path,
-		   int force);
+int write_variable(const char *variable_name, const char *auth_file, const char *path, int force);
 
 /*
  * updates a secure variable by writing data in buffer to the

--- a/backends/host/host_svc_generate.c
+++ b/backends/host/host_svc_generate.c
@@ -32,30 +32,29 @@ struct Arguments {
 };
 
 static int parse_opt(int key, char *arg, struct argp_state *state);
-static int generateHash(const unsigned char *data, size_t size, struct Arguments *args,
+static int generateHash(const uint8_t *data, size_t size, struct Arguments *args,
 			const struct hash_funct *alg, unsigned char **outHash, size_t *outHashSize);
 static int validateHashAndAlg(size_t size, const struct hash_funct *alg);
-static int toESL(const unsigned char *data, size_t size, const uuid_t guid, unsigned char **outESL,
+static int toESL(const unsigned char *data, size_t size, const uuid_t guid, uint8_t **outESL,
 		 size_t *outESLSize);
 static int getHashFunction(const char *name, struct hash_funct **returnFunct);
-static int toPKCS7ForSecVar(const unsigned char *newData, size_t dataSize, struct Arguments *args,
-			    int hashFunct, unsigned char **outBuff, size_t *outBuffSize);
-static int toAuth(const unsigned char *newESL, size_t eslSize, struct Arguments *args,
-		  int hashFunct, unsigned char **outBuff, size_t *outBuffSize);
-static int generateESL(const unsigned char *buff, size_t size, struct Arguments *args,
-		       const struct hash_funct *hashFunct, unsigned char **outBuff,
-		       size_t *outBuffSize);
-static int generateAuthOrPKCS7(const unsigned char *buff, size_t size, struct Arguments *args,
-			       const struct hash_funct *hashFunct, unsigned char **outBuff,
+static int toPKCS7ForSecVar(const uint8_t *newData, size_t dataSize, struct Arguments *args,
+			    int hashFunct, uint8_t **outBuff, size_t *outBuffSize);
+static int toAuth(const uint8_t *newESL, size_t eslSize, struct Arguments *args, int hashFunct,
+		  uint8_t **outBuff, size_t *outBuffSize);
+static int generateESL(const uint8_t *buff, size_t size, struct Arguments *args,
+		       const struct hash_funct *hashFunct, uint8_t **outBuff, size_t *outBuffSize);
+static int generateAuthOrPKCS7(const uint8_t *buff, size_t size, struct Arguments *args,
+			       const struct hash_funct *hashFunct, uint8_t **outBuff,
 			       size_t *outBuffSize);
 static int getTimestamp(struct efi_time *ts);
-static int getOutputData(const unsigned char *buff, size_t size, struct Arguments *args,
-			 const struct hash_funct *hashFunction, unsigned char **outBuff,
+static int getOutputData(const uint8_t *buff, size_t size, struct Arguments *args,
+			 const struct hash_funct *hashFunction, uint8_t **outBuff,
 			 size_t *outBuffSize);
-static int authToESL(const unsigned char *in, size_t inSize, unsigned char **out, size_t *outSize);
-static int toHashForSecVarSigning(const unsigned char *ESL, size_t ESL_size, struct Arguments *args,
-				  unsigned char **outBuff, size_t *outBuffSize);
-static int getPreHashForSecVar(unsigned char **outData, size_t *outSize, const unsigned char *ESL,
+static int authToESL(const uint8_t *in, size_t inSize, uint8_t **out, size_t *outSize);
+static int toHashForSecVarSigning(const uint8_t *ESL, size_t ESL_size, struct Arguments *args,
+				  uint8_t **outBuff, size_t *outBuffSize);
+static int getPreHashForSecVar(uint8_t **outData, size_t *outSize, const uint8_t *ESL,
 			       size_t ESL_size, struct Arguments *args);
 static int parseCustomTimestamp(struct efi_time *strct, const char *str);
 static void convert_tm_to_efi_time(struct efi_time *efi_t, struct tm *tm_t);
@@ -71,7 +70,7 @@ int performGenerateCommand(int argc, char *argv[])
 	int rc;
 	size_t outBuffSize, size;
 	struct hash_funct *hashFunction;
-	unsigned char *buff = NULL, *outBuff = NULL;
+	uint8_t *buff = NULL, *outBuff = NULL;
 	struct Arguments args = { .helpFlag = 0,
 				  .inpValid = 0,
 				  .signKeyCount = 0,
@@ -193,7 +192,7 @@ int performGenerateCommand(int argc, char *argv[])
 		size = 0;
 	else {
 		// get data from input file
-		buff = (unsigned char *)get_data_from_file(args.inFile, SIZE_MAX, &size);
+		buff = get_data_from_file(args.inFile, SIZE_MAX, &size);
 		if (buff == NULL) {
 			prlog(PR_ERR, "ERROR: Could not find data in file %s\n", args.inFile);
 			rc = INVALID_FILE;
@@ -216,7 +215,7 @@ int performGenerateCommand(int argc, char *argv[])
 
 	prlog(PR_INFO, "Writing %zu bytes to %s\n", outBuffSize, args.outFile);
 	// write data to new file
-	rc = create_file(args.outFile, (char *)outBuff, outBuffSize);
+	rc = create_file(args.outFile, outBuff, outBuffSize);
 	if (rc) {
 		prlog(PR_ERR, "ERROR: Could not write new data to output file %s\n", args.outFile);
 	}
@@ -409,8 +408,8 @@ static int parseCustomTimestamp(struct efi_time *strct, const char *str)
  *@param outBuffSize, the length of outBuff
  *@return SUCCESS or err number 
  */
-static int getOutputData(const unsigned char *buff, size_t size, struct Arguments *args,
-			 const struct hash_funct *hashFunction, unsigned char **outBuff,
+static int getOutputData(const uint8_t *buff, size_t size, struct Arguments *args,
+			 const struct hash_funct *hashFunction, uint8_t **outBuff,
 			 size_t *outBuffSize)
 {
 	int rc;

--- a/backends/host/host_svc_read.c
+++ b/backends/host/host_svc_read.c
@@ -14,11 +14,11 @@
 #include "host_svc_backend.h"
 
 static int readFiles(const char *var, const char *file, int hrFlag, const char *path);
-static int printReadable(const char *c, size_t size, const char *key);
+static int printReadable(const uint8_t *c, size_t size, const char *key);
 static int readFileFromSecVar(const char *path, const char *variable, int hrFlag);
 static int readFileFromPath(const char *path, int hrFlag);
 static int getSizeFromSizeFile(size_t *returnSize, const char *path);
-static int readTS(const char *data, size_t size);
+static int readTS(const uint8_t *data, size_t size);
 
 struct Arguments {
 	int helpFlag, printRaw;
@@ -234,7 +234,7 @@ static int readFileFromPath(const char *file, int hrFlag)
 {
 	int rc;
 	size_t size = 0;
-	char *c = NULL;
+	uint8_t *c = NULL;
 	c = get_data_from_file(file, SIZE_MAX, &size);
 	if (!c) {
 		return INVALID_FILE;
@@ -265,7 +265,8 @@ int getSecVar(struct secvar **var, const char *name, const char *fullPath)
 {
 	int rc;
 	size_t size, out_size;
-	char *sizePath = NULL, *c = NULL;
+	char *sizePath = NULL;
+	uint8_t *c = NULL;
 	rc = is_file(fullPath);
 	if (rc) {
 		return rc;
@@ -330,7 +331,7 @@ int getSecVar(struct secvar **var, const char *name, const char *fullPath)
  *@param key, variable name {"db","dbx","KEK", "PK"} b/c dbx is a different format
  *@return SUCCESS or error number if failure
  */
-static int printReadable(const char *c, size_t size, const char *key)
+static int printReadable(const uint8_t *c, size_t size, const char *key)
 {
 	ssize_t eslvarsize = size;
 	int count = 0, offset = 0, rc;
@@ -372,7 +373,7 @@ static int printReadable(const char *c, size_t size, const char *key)
 		eslsize = sigList->SignatureListSize;
 		printESLInfo(sigList);
 		// puts sig data in cert
-		cert_size = get_esl_cert(c + offset, eslvarsize, (char **)&cert);
+		cert_size = get_esl_cert(c + offset, eslvarsize, &cert);
 		if (cert_size <= 0) {
 			prlog(PR_ERR, "\tERROR: Signature Size was too small, no data \n");
 			break;
@@ -451,7 +452,7 @@ int printCertInfo(crypto_x509_t *x509)
  *@param size, size of timestamp data, should be 16*4
  *@return SUCCESS or error depending if ts data is understandable
  */
-static int readTS(const char *data, size_t size)
+static int readTS(const uint8_t *data, size_t size)
 {
 	struct efi_time *tmpStamp;
 	// data length must have a timestamp for every variable besides the TS variable

--- a/backends/host/host_svc_verify.c
+++ b/backends/host/host_svc_verify.c
@@ -543,12 +543,12 @@ static void printBanks(struct list_head *variable_bank, struct list_head *update
 	struct secvar *var = NULL;
 	printf("----CONTENTS OF UPDATE BANK----\n");
 	list_for_each (update_bank, var, link) {
-		printf("SecVar for %s contains %zd bytes of data\n", var->key, var->data_size);
+		printf("SecVar for %s contains %lu bytes of data\n", var->key, var->data_size);
 	}
 
 	printf("----CONTENTS OF VARIABLE BANK----\n");
 	list_for_each (variable_bank, var, link) {
-		printf("SecVar for %s contains %zd bytes of data\n", var->key, var->data_size);
+		printf("SecVar for %s contains %lu bytes of data\n", var->key, var->data_size);
 	}
 }
 
@@ -563,7 +563,7 @@ static int commitUpdateBank(struct list_head *update_bank, const char *path)
 	int rc = INVALID_FILE;
 	struct secvar *var = NULL;
 	list_for_each (update_bank, var, link) {
-		prlog(PR_INFO, "Writing new %s with %zd bytes of data to %s%s/update\n", var->key,
+		prlog(PR_INFO, "Writing new %s with %lu bytes of data to %s%s/update\n", var->key,
 		      var->data_size, path, var->key);
 		rc = updateVar(path, var->key, var->data, var->data_size);
 		if (rc) {

--- a/backends/host/host_svc_verify.c
+++ b/backends/host/host_svc_verify.c
@@ -314,7 +314,7 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 	int defaultVarsFlag = 0;
 	size_t len;
 	struct secvar *tmp = NULL;
-	char *c;
+	uint8_t *c;
 
 	// if current vars string is given, check it. if not, get default/path vars
 	if (!currentVars) {
@@ -336,7 +336,7 @@ static int setupBanks(struct list_head *variable_bank, struct list_head *update_
 	// once here, strings should be ready, it is time to fill banks
 	// fill update bank with all updates
 	for (int i = 0; i < updateCount; i += 2) {
-		c = get_data_from_file((char *)updateVars[i + 1], SIZE_MAX, &len);
+		c = get_data_from_file(updateVars[i + 1], SIZE_MAX, &len);
 		if (c) {
 			list_add_tail(update_bank, &new_secvar(updateVars[i],
 							       strlen(updateVars[i]) + 1, c, len, 0)
@@ -402,7 +402,7 @@ static int validateBanks(struct list_head *update_bank, struct list_head *variab
 			      var->key);
 			return rc;
 		}
-		rc = validateAuth((unsigned char *)var->data, var->data_size, var->key);
+		rc = validateAuth(var->data, var->data_size, var->key);
 		if (rc) {
 			prlog(PR_ERR, "ERROR: failed to validate Auth file for %s, returned %d\n",
 			      var->key, rc);
@@ -415,10 +415,9 @@ static int validateBanks(struct list_head *update_bank, struct list_head *variab
 		list_for_each (variable_bank, var, link) {
 			prlog(PR_INFO, "----VALIDATING CURRENT VAR: %s----\n", var->key);
 			if (strcmp(var->key, "TS") == 0)
-				rc = validateTS((unsigned char *)var->data, var->data_size);
+				rc = validateTS(var->data, var->data_size);
 			else
-				rc = validateESL((unsigned char *)var->data, var->data_size,
-						 var->key);
+				rc = validateESL(var->data, var->data_size, var->key);
 			if (rc) {
 				prlog(PR_ERR,
 				      "ERROR: failed to validate data file for %s,returned %d\n",
@@ -566,7 +565,7 @@ static int commitUpdateBank(struct list_head *update_bank, const char *path)
 	list_for_each (update_bank, var, link) {
 		prlog(PR_INFO, "Writing new %s with %zd bytes of data to %s%s/update\n", var->key,
 		      var->data_size, path, var->key);
-		rc = updateVar(path, var->key, (unsigned char *)var->data, var->data_size);
+		rc = updateVar(path, var->key, var->data, var->data_size);
 		if (rc) {
 			prlog(PR_ERR, "ERROR: issue writing to file #%d\n",
 			      rc); // consider continuing

--- a/backends/host/host_svc_write.c
+++ b/backends/host/host_svc_write.c
@@ -156,7 +156,7 @@ int isVariable(const char *var)
 static int updateSecVar(const char *varName, const char *authFile, const char *path, int force)
 {
 	int rc;
-	unsigned char *buff = NULL;
+	uint8_t *buff = NULL;
 	size_t size;
 
 	if (!path) {
@@ -164,7 +164,7 @@ static int updateSecVar(const char *varName, const char *authFile, const char *p
 	}
 
 	// get data to write, if force flag then validate the data is an auth file
-	buff = (unsigned char *)get_data_from_file(authFile, SIZE_MAX, &size);
+	buff = get_data_from_file(authFile, SIZE_MAX, &size);
 	// if we are validating and validating fails, quit
 	if (!force) {
 		rc = validateAuth(buff, size, varName);

--- a/external/skiboot/libstb/secvar/backend/edk2-compat-process.c
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat-process.c
@@ -359,11 +359,9 @@ int validate_esl_list(const char *key, const uint8_t *esl, const size_t size)
 }
 
 /* Get the timestamp for the last update of the give key */
-static struct efi_time *get_last_timestamp(const char *key, char *last_timestamp)
+static struct efi_time *get_last_timestamp(const char *key, struct efi_time *timestamp)
 {
-	struct efi_time *timestamp = (struct efi_time*)last_timestamp;
-
-	if (!last_timestamp)
+	if (!timestamp)
 		return NULL;
 
 	if (key_equals(key, "PK"))
@@ -378,7 +376,7 @@ static struct efi_time *get_last_timestamp(const char *key, char *last_timestamp
 		return NULL;
 }
 
-int update_timestamp(const char *key, const struct efi_time *timestamp, char *last_timestamp)
+int update_timestamp(const char *key, const struct efi_time *timestamp, struct efi_time last_timestamp[])
 {
 	struct efi_time *prev;
 
@@ -413,7 +411,7 @@ static uint64_t unpack_timestamp(const struct efi_time *timestamp)
 }
 
 int check_timestamp(const char *key, const struct efi_time *timestamp,
-		    char *last_timestamp)
+		    struct efi_time last_timestamp[])
 {
 	struct efi_time *prev;
 	uint64_t new;
@@ -748,7 +746,7 @@ bool is_pkcs7_sig_format(const void *data)
 
 int process_update(const struct secvar *update, uint8_t **newesl,
 		   int *new_data_size, struct efi_time *timestamp,
-		   struct list_head *bank, char *last_timestamp)
+		   struct list_head *bank, struct efi_time last_timestamp[])
 {
 	struct efi_variable_authentication_2 *auth = NULL;
 	void *auth_buffer = NULL;

--- a/external/skiboot/libstb/secvar/backend/edk2-compat-process.h
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat-process.h
@@ -65,10 +65,10 @@ int get_auth_descriptor2(const void *buf, const size_t buflen,
 int validate_esl_list(const char *key, const uint8_t *esl, const size_t size);
 
 /* Update the TS variable with the new timestamp */
-int update_timestamp(const char *key, const struct efi_time *timestamp, char *last_timestamp);
+int update_timestamp(const char *key, const struct efi_time *timestamp, struct efi_time last_timestamp[]);
 
 /* Check the new timestamp against the timestamp last update was done */
-int check_timestamp(const char *key, const struct efi_time *timestamp, char *last_timestamp);
+int check_timestamp(const char *key, const struct efi_time *timestamp, struct efi_time last_timestamp[]);
 
 /* Check the GUID of the data type */
 bool is_pkcs7_sig_format(const void *data);
@@ -76,7 +76,7 @@ bool is_pkcs7_sig_format(const void *data);
 /* Process the update */
 int process_update(const struct secvar *update, uint8_t **newesl,
 		   int *neweslsize, struct efi_time *timestamp,
-		   struct list_head *bank, char *last_timestamp);
+		   struct list_head *bank, struct efi_time last_timestamp[]);
 
 
 /* Functions used by external secvarctl */

--- a/external/skiboot/libstb/secvar/backend/edk2-compat-process.h
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat-process.h
@@ -51,7 +51,7 @@ extern bool setup_mode;
 extern struct list_head staging_bank;
 
 /* Update the variable in the variable bank with the new value. */
-int update_variable_in_bank(struct secvar *update_var, const char *data,
+int update_variable_in_bank(struct secvar *update_var, const uint8_t *data,
 			    uint64_t dsize, struct list_head *bank);
 
 /* This function outputs the Authentication 2 Descriptor in the
@@ -62,7 +62,7 @@ int get_auth_descriptor2(const void *buf, const size_t buflen,
 			 void **auth_buffer);
 
 /* Check the format of the ESL */
-int validate_esl_list(const char *key, const char *esl, const size_t size);
+int validate_esl_list(const char *key, const uint8_t *esl, const size_t size);
 
 /* Update the TS variable with the new timestamp */
 int update_timestamp(const char *key, const struct efi_time *timestamp, char *last_timestamp);
@@ -74,7 +74,7 @@ int check_timestamp(const char *key, const struct efi_time *timestamp, char *las
 bool is_pkcs7_sig_format(const void *data);
 
 /* Process the update */
-int process_update(const struct secvar *update, char **newesl,
+int process_update(const struct secvar *update, uint8_t **newesl,
 		   int *neweslsize, struct efi_time *timestamp,
 		   struct list_head *bank, char *last_timestamp);
 
@@ -88,7 +88,7 @@ int process_update(const struct secvar *update, char **newesl,
  * @return NULL if buflen is smaller than size of sig list struct or if buf is NULL
  * @return EFI_SIGNATURE_LIST struct
  */
-EFI_SIGNATURE_LIST* get_esl_signature_list(const char *buf, size_t buflen);
+EFI_SIGNATURE_LIST* get_esl_signature_list(const uint8_t *buf, size_t buflen);
 
 /**
  * Copies the certificate from the ESL into cert buffer and returns the size
@@ -98,7 +98,7 @@ EFI_SIGNATURE_LIST* get_esl_signature_list(const char *buf, size_t buflen);
  * @param cert pointer to destination. Memory will be allocated for the certificate
  * @return size of memory allocated to cert or negative number if allocation fails
  */
-int get_esl_cert(const char *buf, const size_t buflen, char **cert);
+int get_esl_cert(const uint8_t *buf, const size_t buflen, uint8_t **cert);
 
 /*
  * Extracts size of the PKCS7 signed data embedded in the

--- a/external/skiboot/libstb/secvar/backend/edk2-compat.c
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat.c
@@ -109,7 +109,7 @@ static int edk2_compat_process(struct list_head *variable_bank,
 	struct secvar *var = NULL;
 	struct secvar *tsvar = NULL;
 	struct efi_time timestamp;
-	char *newesl = NULL;
+	uint8_t *newesl = NULL;
 	int neweslsize;
 	int rc = 0;
 
@@ -167,7 +167,8 @@ static int edk2_compat_process(struct list_head *variable_bank,
 		rc = process_update(var, &newesl,
 				    &neweslsize, &timestamp,
 				    &staging_bank,
-				    tsvar->data);
+					// TODO
+				    (char *)tsvar->data);
 		if (rc) {
 			prlog(PR_ERR, "Update processing failed with rc %04x\n", rc);
 			break;
@@ -191,7 +192,7 @@ static int edk2_compat_process(struct list_head *variable_bank,
 		/* Update the TS variable with the new timestamp */
 		rc = update_timestamp(var->key,
 				      &timestamp,
-				      tsvar->data);
+				      (char *)tsvar->data);
 		if (rc) {
 			prlog (PR_ERR, "Variable updated, but timestamp updated failed %04x\n", rc);
 			break;

--- a/external/skiboot/libstb/secvar/backend/edk2-compat.c
+++ b/external/skiboot/libstb/secvar/backend/edk2-compat.c
@@ -167,8 +167,7 @@ static int edk2_compat_process(struct list_head *variable_bank,
 		rc = process_update(var, &newesl,
 				    &neweslsize, &timestamp,
 				    &staging_bank,
-					// TODO
-				    (char *)tsvar->data);
+				    (struct efi_time *) tsvar->data); // TS contains a fixed-array of struct efi_time
 		if (rc) {
 			prlog(PR_ERR, "Update processing failed with rc %04x\n", rc);
 			break;
@@ -192,7 +191,7 @@ static int edk2_compat_process(struct list_head *variable_bank,
 		/* Update the TS variable with the new timestamp */
 		rc = update_timestamp(var->key,
 				      &timestamp,
-				      (char *)tsvar->data);
+				      (struct efi_time *) tsvar->data); // TS contains a fixed-array of struct efi_time
 		if (rc) {
 			prlog (PR_ERR, "Variable updated, but timestamp updated failed %04x\n", rc);
 			break;

--- a/external/skiboot/libstb/secvar/secvar.h
+++ b/external/skiboot/libstb/secvar/secvar.h
@@ -25,7 +25,7 @@ struct secvar {
 	uint64_t data_size;
 	uint64_t flags;
 	char *key;
-	char *data;
+	uint8_t *data;
 };
 
 extern struct list_head variable_bank;
@@ -40,7 +40,7 @@ void clear_bank_list(struct list_head *bank);
 int copy_bank_list(struct list_head *dst, struct list_head *src);
 struct secvar *alloc_secvar(uint64_t key_len, uint64_t data_size);
 struct secvar *new_secvar(const char *key, uint64_t key_len,
-			       const char *data, uint64_t data_size,
+			       const uint8_t *data, uint64_t data_size,
 			       uint64_t flags);
 int realloc_secvar(struct secvar *node, uint64_t size);
 void dealloc_secvar(struct secvar *node);

--- a/external/skiboot/libstb/secvar/secvar.h
+++ b/external/skiboot/libstb/secvar/secvar.h
@@ -28,8 +28,10 @@ struct secvar {
 	uint8_t *data;
 };
 
-extern struct list_head variable_bank;
-extern struct list_head update_bank;
+// NOTE: Commented out as these globals are not used in secvarctl, and causes
+//  variable shadowing warnings in cppcheck.
+// extern struct list_head variable_bank;
+// extern struct list_head update_bank;
 extern int secvar_enabled;
 extern int secvar_ready;
 extern struct secvar_storage_driver secvar_storage;

--- a/external/skiboot/libstb/secvar/secvar_util.c
+++ b/external/skiboot/libstb/secvar/secvar_util.c
@@ -70,7 +70,7 @@ struct secvar *alloc_secvar(uint64_t key_len, uint64_t data_size)
 }
 
 struct secvar *new_secvar(const char *key, uint64_t key_len,
-			       const char *data, uint64_t data_size,
+			       const uint8_t *data, uint64_t data_size,
 			       uint64_t flags)
 {
 	struct secvar *ret;

--- a/generic.c
+++ b/generic.c
@@ -2,6 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright 2022-2023 IBM Corp.
  */
+#include <bits/stdint-uintn.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
@@ -47,7 +48,7 @@ void print_hex(const uint8_t *data, size_t length)
  * @param c pointer to buffer
  * @param size length of buffer
  */
-void print_raw(const char *c, size_t size)
+void print_raw(const uint8_t *c, size_t size)
 {
 	for (int i = 0; i < size; i++)
 		printf("%c", *(c + i));
@@ -63,10 +64,10 @@ void print_raw(const char *c, size_t size)
  * @return char* to allocted data of file
  * NOTE:REMEMBER TO UNALLOCATE RETURNED DATA
  */
-char *get_data_from_file(const char *fullPath, size_t max_bytes, size_t *size)
+uint8_t *get_data_from_file(const char *fullPath, size_t max_bytes, size_t *size)
 {
 	int fptr;
-	char *buffer = NULL;
+	uint8_t *buffer = NULL;
 	struct stat fileInfo;
 	ssize_t read_size;
 
@@ -149,7 +150,7 @@ int write_data_to_file(const char *file, const char *buff, size_t size)
  * @return negative int, error if opening/writing to .../update file
  * @return 0 for success or error number
  */
-int create_file(const char *file, const char *buff, size_t size)
+int create_file(const char *file, const uint8_t *buff, size_t size)
 {
 	int rc, fptr;
 

--- a/include/generic.h
+++ b/include/generic.h
@@ -6,6 +6,7 @@
 #define GENERIC_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 #define ARGP_OPT_USAGE_KEY 0x100
 
@@ -14,10 +15,10 @@ struct command {
 	int (*func)(int, char **);
 };
 
-char *get_data_from_file(const char *file, size_t max_size, size_t *size);
+uint8_t *get_data_from_file(const char *file, size_t max_size, size_t *size);
 int write_data_to_file(const char *file, const char *buff, size_t size);
-int create_file(const char *file, const char *buff, size_t size);
-void print_raw(const char *c, size_t size);
+int create_file(const char *file, const uint8_t *buff, size_t size);
+void print_raw(const uint8_t *c, size_t size);
 int is_file(const char *path);
 void print_hex(const uint8_t *data, size_t length);
 int realloc_array(void **arr, size_t new_length, size_t size_each);

--- a/secvarctl.c
+++ b/secvarctl.c
@@ -160,7 +160,8 @@ static struct backend *get_backend()
 			max_buff_size = strlen(backends[i].format);
 	}
 
-	buff = get_data_from_file(secvar_format_location, max_buff_size, &buffSize);
+	// Contents of format file should be a string
+	buff = (char *)get_data_from_file(secvar_format_location, max_buff_size, &buffSize);
 	if (buff == NULL) {
 		prlog(PR_WARNING,
 		      "WARNING!! could not extract data from %s , "


### PR DESCRIPTION
## Type Overhaul

Buffer types are inconsistent across the project -- some bits use `char *`, `unsigned char *`, `uint8_t *`, etc. This PR attempts to unify all buffer types to use the same type to avoid needless casting.

The following has been done:
 - use `uint8_t *` for raw pointers to data (buffers)
 - use `char *` for strings and (hopefully) *only* strings
 - comment the few cases where a cast is necessary
   - this is primarily when loading data from a file that IS a string, or similar cases

---
## Static Analysis Stuff

Due to laziness on my part, I'm also piggybacking some static analysis fixes into this PR. These checks are not reported by the version of cppcheck that actions uses (2.7), but are included in the newer 2.12 version.

The changes are mostly minor:
 - ignore checking ccan headers, as we will not be amending those
 - use more `const`
 - scope reductions
 - suppress `unusedSuppression`, as cppcheck v2.12.1 didn't match some of the existing suppression. This should be reevaluated Later™
 - fix potential NULL reference in the PK/append special case

---
## On Skiboot changes

While I'd rather not amend external ccan headers, I did make some changes to the external skiboot code. While really that code should be reworked to work better as a library (and changes sent upstream), that is likely not going to happen. Thus, I have made some changes directly to the skiboot code to address more type issues and one static analysis fix. If we deem it necessary in the future, we should consider a full overhaul of the skiboot secure boot code (mostly reorganizing), and ship it to skiboot purely so that the files are consistent again. I will open a separate future-milestoned issue to keep this in mind, and it can be closed if we decide this isn't something we want to bother with.