### PR TITLE
Add missing patches from internal version, redux

### DIFF
--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -13,12 +13,6 @@
 #include "common/util.h"
 #include "common/read.h"
 
-void print_timestamp(timestamp_t t)
-{
-	printf("%04d-%02d-%02d %02d:%02d:%02d UTC\n", t.year, t.month, t.day, t.hour, t.minute,
-	       t.second);
-}
-
 sv_esl_t *extract_esl_signature_list(const uint8_t *buf, size_t buflen)
 {
 	sv_esl_t *list = NULL;

--- a/backends/guest/common/util.c
+++ b/backends/guest/common/util.c
@@ -45,17 +45,14 @@ void print_timestamp(timestamp_t t)
 	       t.second);
 }
 
-void read_timestamp(const uint8_t *esl_data)
+void read_timestamp(const struct signed_variable_header *data)
 {
 	timestamp_t timestamp;
 
-	if (esl_data == NULL)
+	if (data == NULL)
 		return;
 
-	// Special case: data read in from firmware contains a 16-bytes header, containing
-	//  a one-byte version number, then 15 bytes of timestamp -- truncating the trailing
-	//  padding byte at the end of the struct.
-	memcpy(&timestamp, esl_data + 1, TIMESTAMP_LEN - 1);
+	memcpy(&timestamp, &data->timestamp, sizeof(data->timestamp));
 	printf("\tTimestamp: ");
 	print_timestamp(timestamp);
 }

--- a/backends/guest/common/util.c
+++ b/backends/guest/common/util.c
@@ -31,6 +31,14 @@ const struct signature_type_info signature_type_list[] = {
 static uint8_t append[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 static uint8_t replace[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
+/*
+ * check it whether given variable is trustedcadb
+ */
+bool is_trustedcadb_variable(const char *variable_name)
+{
+	return !strcmp(variable_name, TRUSTEDCADB_VARIABLE);
+}
+
 void print_timestamp(timestamp_t t)
 {
 	printf("%04d-%02d-%02d %02d:%02d:%02d UTC\n", t.year, t.month, t.day, t.hour, t.minute,

--- a/backends/guest/common/util.c
+++ b/backends/guest/common/util.c
@@ -31,6 +31,27 @@ const struct signature_type_info signature_type_list[] = {
 static uint8_t append[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 };
 static uint8_t replace[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
 
+void print_timestamp(timestamp_t t)
+{
+	printf("%04d-%02d-%02d %02d:%02d:%02d UTC\n", t.year, t.month, t.day, t.hour, t.minute,
+	       t.second);
+}
+
+void read_timestamp(const uint8_t *esl_data)
+{
+	timestamp_t timestamp;
+
+	if (esl_data == NULL)
+		return;
+
+	// Special case: data read in from firmware contains a 16-bytes header, containing
+	//  a one-byte version number, then 15 bytes of timestamp -- truncating the trailing
+	//  padding byte at the end of the struct.
+	memcpy(&timestamp, esl_data + 1, TIMESTAMP_LEN - 1);
+	printf("\tTimestamp: ");
+	print_timestamp(timestamp);
+}
+
 /*
  * creates the append header using append flag
  */

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -100,7 +100,8 @@ static int get_current_esl_data(const char *esl_file, uint8_t **current_esl_data
 	buffer = get_data_from_file(esl_file, SIZE_MAX, &buffer_size);
 	if (buffer != NULL && buffer_size >= TIMESTAMP_LEN) {
 		if (buffer_size == DEFAULT_PK_LEN) {
-			print_raw(buffer, buffer_size);
+			if (verbose >= PR_DEBUG)
+				print_raw(buffer, buffer_size);
 			free(buffer);
 			buffer = NULL;
 			buffer_size = 0;

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -71,9 +71,10 @@ static int update_variable(const char *variable_name, const uint8_t *auth_data,
 		prlog(PR_INFO, "\tappend update: %s\n\n", (append_update ? "True" : "False"));
 
 		if (*new_esl_data != NULL) {
-			read_timestamp(*new_esl_data);
-			rc = print_esl_buffer((*new_esl_data + TIMESTAMP_LEN),
-					      (*new_esl_data_size - TIMESTAMP_LEN), variable_name);
+			read_timestamp((struct signed_variable_header *)*new_esl_data);
+			rc = print_esl_buffer((*new_esl_data + GUEST_HEADER_LEN),
+					      (*new_esl_data_size - GUEST_HEADER_LEN),
+					      variable_name);
 			if (rc != SUCCESS)
 				return rc;
 		}
@@ -98,7 +99,7 @@ static int get_current_esl_data(const char *esl_file, uint8_t **current_esl_data
 	}
 
 	buffer = get_data_from_file(esl_file, SIZE_MAX, &buffer_size);
-	if (buffer != NULL && buffer_size >= TIMESTAMP_LEN) {
+	if (buffer != NULL && buffer_size >= GUEST_HEADER_LEN) {
 		if (buffer_size == DEFAULT_PK_LEN) {
 			if (verbose >= PR_DEBUG)
 				print_raw(buffer, buffer_size);
@@ -107,8 +108,9 @@ static int get_current_esl_data(const char *esl_file, uint8_t **current_esl_data
 			buffer_size = 0;
 		} else {
 			if (verbose >= PR_INFO)
-				read_timestamp(buffer);
-			rc = validate_esl(buffer + TIMESTAMP_LEN, buffer_size - TIMESTAMP_LEN);
+				read_timestamp((struct signed_variable_header *)buffer);
+			rc = validate_esl(buffer + GUEST_HEADER_LEN,
+					  buffer_size - GUEST_HEADER_LEN);
 			if (rc != SUCCESS) {
 				free(buffer);
 				return rc;

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -92,8 +92,10 @@ static int get_current_esl_data(const char *esl_file, uint8_t **current_esl_data
 	size_t buffer_size = 0;
 	uint8_t *buffer = NULL;
 
-	if (is_file(esl_file) != SUCCESS)
+	if (is_file(esl_file) != SUCCESS) {
+		prlog(PR_ERR, "ERROR: %s is not a valid file\n", (char *)esl_file);
 		return INVALID_FILE;
+	}
 
 	buffer = get_data_from_file(esl_file, SIZE_MAX, &buffer_size);
 	if (buffer != NULL && buffer_size >= TIMESTAMP_LEN) {
@@ -112,7 +114,7 @@ static int get_current_esl_data(const char *esl_file, uint8_t **current_esl_data
 			}
 		}
 	} else
-		return INVALID_FILE;
+		prlog(PR_WARNING, "WARNING: %s file does not have data\n", (char *)esl_file);
 
 	*current_esl_data = buffer;
 	*current_esl_data_size = buffer_size;
@@ -130,8 +132,10 @@ static int get_auth_data(const char *auth_file, uint8_t **auth_data, size_t *aut
 	size_t buffer_size = 0;
 	uint8_t *buffer = NULL;
 
-	if (is_file(auth_file) != SUCCESS)
+	if (is_file(auth_file) != SUCCESS) {
+		prlog(PR_ERR, "ERROR: %s is not a valid file\n", (char *)auth_file);
 		return INVALID_FILE;
+	}
 
 	buffer = (uint8_t *)get_data_from_file(auth_file, SIZE_MAX, &buffer_size);
 	if (buffer != NULL) {
@@ -140,8 +144,10 @@ static int get_auth_data(const char *auth_file, uint8_t **auth_data, size_t *aut
 			free(buffer);
 			return rc;
 		}
-	} else
+	} else {
+		prlog(PR_WARNING, "WARNING: %s file does not have data\n", (char *)auth_file);
 		return INVALID_FILE;
+	}
 
 	*append_update = extract_append_header(buffer, buffer_size);
 	*auth_data = buffer;

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -465,17 +465,16 @@ int validate_variables_arguments(struct verify_args *args)
 			      "<var_name 1> <var_auth_file 1>"
 			      "...<var_name N> <var_auth_file N>\n");
 		return ARG_PARSE_FAIL;
+	} else if (args->current_variable_size != 0 && args->current_variable_size % 2) {
+		prlog(PR_ERR, "ERROR: current variable argument should be like -c "
+			      "<var_name 1> <var_ESL_file 1>...<var_name N> <var_ESL_file N>\n");
+		return ARG_PARSE_FAIL;
 	}
 
 	if (args->current_variable_size != 0) {
 		if (args->write_flag) {
-			prlog(PR_ERR, "ERROR: cannot update files if current variable "
-				      "files are given. remove -w\n");
-			return ARG_PARSE_FAIL;
-		} else if (args->current_variable_size % 2) {
-			prlog(PR_ERR, "ERROR: current variable argument should be like -c "
-				      "<var_name 1> <var_ESL_file 1>"
-				      "...<var_name N> <var_ESL_file N>\n");
+			prlog(PR_ERR,
+			      "ERROR: cannot update files. remove -w. it is available when you use -u with -p\n");
 			return ARG_PARSE_FAIL;
 		}
 	}

--- a/backends/guest/common/verify.c
+++ b/backends/guest/common/verify.c
@@ -71,6 +71,7 @@ static int update_variable(const char *variable_name, const uint8_t *auth_data,
 		prlog(PR_INFO, "\tappend update: %s\n\n", (append_update ? "True" : "False"));
 
 		if (*new_esl_data != NULL) {
+			read_timestamp(*new_esl_data);
 			rc = print_esl_buffer((*new_esl_data + TIMESTAMP_LEN),
 					      (*new_esl_data_size - TIMESTAMP_LEN), variable_name);
 			if (rc != SUCCESS)
@@ -95,13 +96,15 @@ static int get_current_esl_data(const char *esl_file, uint8_t **current_esl_data
 		return INVALID_FILE;
 
 	buffer = get_data_from_file(esl_file, SIZE_MAX, &buffer_size);
-	if (buffer != NULL) {
+	if (buffer != NULL && buffer_size >= TIMESTAMP_LEN) {
 		if (buffer_size == DEFAULT_PK_LEN) {
 			print_raw(buffer, buffer_size);
 			free(buffer);
 			buffer = NULL;
 			buffer_size = 0;
-		} else if (buffer_size != TIMESTAMP_LEN) {
+		} else {
+			if (verbose >= PR_INFO)
+				read_timestamp(buffer);
 			rc = validate_esl(buffer + TIMESTAMP_LEN, buffer_size - TIMESTAMP_LEN);
 			if (rc != SUCCESS) {
 				free(buffer);

--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -70,7 +70,8 @@ static int generate_esl(const uint8_t *buffer, size_t buffer_size, struct genera
 			break;
 		}
 
-		rc = get_hash_data(buffer, buffer_size, hash_funct, hash_data, &hash_data_size);
+		rc = get_hash_data(buffer, buffer_size, hash_funct, args->variable_name, hash_data,
+				   &hash_data_size);
 		if (rc != SUCCESS) {
 			prlog(PR_ERR, "ERROR: failed to generate hash from file\n");
 			break;
@@ -91,8 +92,9 @@ static int generate_esl(const uint8_t *buffer, size_t buffer_size, struct genera
 		esl_guid = get_uuid(hash_funct);
 		break;
 	case 'c':
-		if (is_x509certificate(buffer, buffer_size, &cert_data, &cert_data_size) !=
-		    SUCCESS) {
+		rc = is_x509certificate(buffer, buffer_size, &cert_data, &cert_data_size,
+					is_trustedcadb_variable(args->variable_name));
+		if (rc != SUCCESS) {
 			prlog(PR_ERR, "ERROR: could not validate certificate\n");
 			break;
 		}
@@ -167,7 +169,8 @@ static int generate_sha256_hash(const uint8_t *data, size_t data_size, struct ge
 			rc = SUCCESS;
 			break;
 		case 'c':
-			rc = validate_cert(data, data_size);
+			rc = validate_cert(data, data_size,
+					   is_trustedcadb_variable(args->variable_name));
 			break;
 		case 'e':
 			rc = validate_esl(data, data_size);

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -261,10 +261,11 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 		if (rc == SUCCESS) {
 			if (is_print_raw || esl_data_size == DEFAULT_PK_LEN)
 				print_raw(esl_data, esl_data_size);
-			else if (esl_data_size >= TIMESTAMP_LEN)
+			else if (esl_data_size >= TIMESTAMP_LEN) {
+				read_timestamp(esl_data);
 				rc = print_esl_buffer(esl_data + TIMESTAMP_LEN,
 						      esl_data_size - TIMESTAMP_LEN, variable_name);
-			else
+			} else
 				prlog(PR_WARNING, "WARNING: The %s database is empty.\n",
 				      variable_name);
 
@@ -288,11 +289,12 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 				    (esl_data_size == DEFAULT_PK_LEN &&
 				     strcmp(defined_sb_variables[i], PK_VARIABLE) == 0))
 					print_raw(esl_data, esl_data_size);
-				else if (esl_data_size >= TIMESTAMP_LEN)
+				else if (esl_data_size >= TIMESTAMP_LEN) {
+					read_timestamp(esl_data);
 					rc = print_esl_buffer(esl_data + TIMESTAMP_LEN,
 							      esl_data_size - TIMESTAMP_LEN,
 							      defined_sb_variables[i]);
-				else
+				} else
 					prlog(PR_WARNING, "WARNING: The %s database is empty.\n",
 					      defined_sb_variables[i]);
 

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -266,10 +266,11 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 		if (rc == SUCCESS) {
 			if (is_print_raw || esl_data_size == DEFAULT_PK_LEN)
 				print_raw(esl_data, esl_data_size);
-			else if (esl_data_size >= TIMESTAMP_LEN) {
-				read_timestamp(esl_data);
-				rc = print_esl_buffer(esl_data + TIMESTAMP_LEN,
-						      esl_data_size - TIMESTAMP_LEN, variable_name);
+			else if (esl_data_size >= GUEST_HEADER_LEN) {
+				read_timestamp((struct signed_variable_header *)esl_data);
+				rc = print_esl_buffer(esl_data + GUEST_HEADER_LEN,
+						      esl_data_size - GUEST_HEADER_LEN,
+						      variable_name);
 			} else
 				prlog(PR_WARNING, "WARNING: The %s database is empty.\n",
 				      variable_name);
@@ -294,10 +295,10 @@ static int read_path(const char *path, const int is_print_raw, const char *varia
 				    (esl_data_size == DEFAULT_PK_LEN &&
 				     strcmp(defined_sb_variables[i], PK_VARIABLE) == 0))
 					print_raw(esl_data, esl_data_size);
-				else if (esl_data_size >= TIMESTAMP_LEN) {
-					read_timestamp(esl_data);
-					rc = print_esl_buffer(esl_data + TIMESTAMP_LEN,
-							      esl_data_size - TIMESTAMP_LEN,
+				else if (esl_data_size >= GUEST_HEADER_LEN) {
+					read_timestamp((struct signed_variable_header *)esl_data);
+					rc = print_esl_buffer(esl_data + GUEST_HEADER_LEN,
+							      esl_data_size - GUEST_HEADER_LEN,
 							      defined_sb_variables[i]);
 				} else
 					prlog(PR_WARNING, "WARNING: The %s database is empty.\n",

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -126,7 +126,12 @@ static int read_cert(const uint8_t *cert_data, const size_t cert_data_len, const
 	rc = validate_x509_certificate(x509);
 	if (rc)
 		prlog(PR_ERR, "ERROR: x509 certificate is invalid (%d)\n", rc);
-	else
+	else if (is_trustedcadb_variable(variable_name)) {
+		if (!crypto_x509_is_CA(x509)) {
+			prlog(PR_ERR, "ERROR: it is not CA certificate\n");
+			rc = CERT_FAIL;
+		}
+	} else
 		rc = print_cert_info(x509);
 
 	crypto_x509_free(x509);

--- a/backends/guest/guest_svc_validate.c
+++ b/backends/guest/guest_svc_validate.c
@@ -123,7 +123,7 @@ int guest_validation_command(int argc, char *argv[])
 
 	switch (args.input_form) {
 	case CERT_FILE:
-		rc = validate_cert(buff, size);
+		rc = validate_cert(buff, size, false);
 		break;
 	case ESL_FILE:
 		rc = validate_esl(buff, size);

--- a/backends/guest/guest_svc_verify.c
+++ b/backends/guest/guest_svc_verify.c
@@ -109,7 +109,7 @@ int guest_verify_command(int argc, char *argv[])
 		  "manually set current vars to be contents of CURRENT VAR LIST (see below for format)" },
 		{ "write", 'w', 0, 0,
 		  "if successful, submit the update to be commited upon reboot."
-		  " quivalent to `secvarctl -m guest write`" },
+		  " equivalent to `secvarctl -m guest write`" },
 		{ 0, 'u', "{UPDATE LIST}", OPTION_HIDDEN,
 		  "set update variables (see below for format)" },
 		{ "help", '?', 0, 0, "Give this help list", 1 },
@@ -130,7 +130,7 @@ int guest_verify_command(int argc, char *argv[])
 		" Where <var_name> is one of Guest secure boot variable"
 		" and <var_auth_file> is a properly generated authenticated variable file "
 		"that is"
-		" signed by a current variable with priviledges to approve the update\n\n"
+		" signed by a current variable with privileges to approve the update\n\n"
 		"CURRENT_VAR_LIST:\nOptional, only used when -c is used. formatted as:"
 		" ' -c <var_name 1> < var_ESL_file 1>...<var_name N> <var_ESL_file N> '"
 		" Where <var_name> is one of Guest secure boot variable and"

--- a/backends/guest/include/common/generate.h
+++ b/backends/guest/include/common/generate.h
@@ -127,10 +127,11 @@ int create_auth_msg(const uint8_t *new_esl, const size_t new_esl_size,
  * @param buffer_size , length of buffer
  * @param cert_data, the certificate data
  * @param cert_data_size, the length of certificate data
+ * @param is_CA, CA certificate flag
  * @return SUCCESS or err number
  */
 int is_x509certificate(const uint8_t *buffer, const size_t buffer_size, uint8_t **cert_data,
-		       size_t *cert_data_size);
+		       size_t *cert_data_size, bool is_CA);
 
 /*
  * generate the hash data using input data
@@ -139,12 +140,13 @@ int is_x509certificate(const uint8_t *buffer, const size_t buffer_size, uint8_t 
  * @param buffer_size , length of buffer
  * @param hash_funct, index of hash function information to use for ESL GUID,
  *                   also helps in prevalation, if inform is '[c]ert' then this doesn't matter
+ * @param variable_name, name of the variable
  * @param hash_data, the generated hash data, should already be allocated to hold hash
  * @param hash_data_size, the length of hash data
  * @param esl_guid, signature type of ESL
  * @return SUCCESS or err number
  */
 int get_hash_data(const uint8_t *buffer, const size_t buffer_size, enum signature_type hash_funct,
-		  uint8_t *hash_data, size_t *hash_data_size);
+		  const char *variable_name, uint8_t *hash_data, size_t *hash_data_size);
 
 #endif

--- a/backends/guest/include/common/util.h
+++ b/backends/guest/include/common/util.h
@@ -53,6 +53,10 @@ struct signature_type_info {
 
 extern const struct signature_type_info signature_type_list[];
 
+void print_timestamp(timestamp_t t);
+
+void read_timestamp(const uint8_t *esl_data);
+
 /*
  * creates the append header using append flag
  */

--- a/backends/guest/include/common/util.h
+++ b/backends/guest/include/common/util.h
@@ -10,7 +10,6 @@
 
 #define DEFAULT_PK_LEN 31
 #define APPEND_HEADER_LEN 8
-#define TIMESTAMP_LEN 8
 #define PK_VARIABLE "PK"
 #define PK_LEN 2
 #define KEK_VARIABLE "KEK"
@@ -52,6 +51,8 @@ struct signature_type_info {
 	size_t size;
 };
 
+#define GUEST_HEADER_LEN sizeof(struct signed_variable_header)
+
 extern const struct signature_type_info signature_type_list[];
 
 /*
@@ -61,7 +62,7 @@ bool is_trustedcadb_variable(const char *variable_name);
 
 void print_timestamp(timestamp_t t);
 
-void read_timestamp(const uint8_t *esl_data);
+void read_timestamp(const struct signed_variable_header *esl_data);
 
 /*
  * creates the append header using append flag

--- a/backends/guest/include/common/util.h
+++ b/backends/guest/include/common/util.h
@@ -16,6 +16,7 @@
 #define KEK_VARIABLE "KEK"
 #define KEK_LEN 3
 #define SBAT_VARIABLE "sbat"
+#define TRUSTEDCADB_VARIABLE "trustedcadb"
 
 static const uuid_t PKS_CERT_DELETE_GUID = { { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 					       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 } };
@@ -52,6 +53,11 @@ struct signature_type_info {
 };
 
 extern const struct signature_type_info signature_type_list[];
+
+/*
+ * check it whether given variable is trustedcadb
+ */
+bool is_trustedcadb_variable(const char *variable_name);
 
 void print_timestamp(timestamp_t t);
 

--- a/backends/guest/include/common/validate.h
+++ b/backends/guest/include/common/validate.h
@@ -76,9 +76,10 @@ int validate_esl(const uint8_t *esl_data, size_t esl_data_len);
  *
  * @param certBuf pointer to certificate data
  * @param buflen length of certBuf
+ * @param is_CA, CA certificate flag
  * @return CERT_FAIL if certificate had incorrect data
  * @return SUCCESS if certificate is valid
  */
-int validate_cert(const uint8_t *cert_data, size_t cert_data_len);
+int validate_cert(const uint8_t *cert_data, size_t cert_data_len, bool is_CA);
 
 #endif


### PR DESCRIPTION
Supercedes #75, can be closed when this is merged. This PR contains a set of amended commits, largely squashed down intermediate commits, and applied the fixes as suggested in the previous PR.

---

Notable changes from #75:
 - squashed unnecessary intermediate commits
 - added a comment about the version byte to `read_timestamp()`, further information and work can be tracked in #76 
 - restored `else` error cases that were removed for some reason
 - rebased onto `guest-devel`
 - restored returning `INVALID_FILE` from `guest_current_esl_data` in `common/verify.c`