### PR TITLE
Fix regression cert file read regression in rc3

### DIFF
--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -126,7 +126,7 @@ static int read_cert(const uint8_t *cert_data, const size_t cert_data_len, const
 	rc = validate_x509_certificate(x509);
 	if (rc)
 		prlog(PR_ERR, "ERROR: x509 certificate is invalid (%d)\n", rc);
-	else if (is_trustedcadb_variable(variable_name)) {
+	else if (variable_name && is_trustedcadb_variable(variable_name)) {
 		if (!crypto_x509_is_CA(x509)) {
 			prlog(PR_ERR, "ERROR: it is not CA certificate\n");
 			rc = CERT_FAIL;

--- a/test/guest_tests.py
+++ b/test/guest_tests.py
@@ -92,7 +92,7 @@ def collect_test_data():
         if file.endswith(".auth"):
             auth_files.append(test_dir[1] + file)
     for file in os.listdir(test_dir[2]):
-        if file.endswith(".cert"):
+        if file.endswith(".crt"):
             cert_files.append(test_dir[2] + file)
     for file in os.listdir(test_dir[4]):
         if file.endswith(".pkcs7"):


### PR DESCRIPTION
Addresses #78 

`is_trustedcadb_variable()` expects a non-NULL string as an argument, however `read -c <file>` does not set a variable name, as it is just a file with no context. This bug was introduced by my amendments to the initial version of the missing features PR #77 , where I simplified the `is_trustedcadb_variable()` to be a single call to `strcmp()`.

Fix the regression, by adding a NULL check before calling `is_trustedcadb_variable()`.

---

This also led me to discover another fun point: the test cases did not correctly pick up and test `.crt` files as it should have, and instead was looking for `.cert` files. This has also been addressed, which should have caught this regression before it landed in `-rc3`.