### PR TITLE
Fix generate argument parsing

### DIFF
--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -523,13 +523,6 @@ static int parse_options(int key, char *arg, struct argp_state *state)
 	if (rc)
 		prlog(PR_ERR, "failed during argument parsing\n");
 
-	// Special case, filter out appends on PK
-	if (args->append_flag > 0 && args->variable_name != NULL &&
-	    strcmp(PK_VARIABLE, args->variable_name) == 0) {
-		prlog(PR_ERR, "ERROR: PK does not support the append flag\n");
-		rc = ARG_PARSE_FAIL;
-	}
-
 	return rc;
 }
 
@@ -665,6 +658,14 @@ int guest_generate_command(int argc, char *argv[])
 			prlog(PR_ERR,
 			      "ERROR: number of certificates does not equal number of keys, %d != %d\n",
 			      args.sign_cert_count, args.sign_key_count);
+		rc = ARG_PARSE_FAIL;
+		goto out;
+	}
+
+	/* special case, filter out appends on PK */
+	if (args.append_flag > 0 && args.variable_name != NULL &&
+	    strcmp(PK_VARIABLE, args.variable_name) == 0) {
+		prlog(PR_ERR, "ERROR: PK does not support the append flag\n");
 		rc = ARG_PARSE_FAIL;
 		goto out;
 	}

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,6 +14,8 @@ GNUTLS = 0
 HOST_BACKEND = 1
 GUEST_BACKEND = 1
 
+export ASAN_OPTIONS = abort_on_error=1
+
 define test_host
 	@$(py) host_tests.py
 	@$(py) host_generate_tests.py

--- a/test/common.py
+++ b/test/common.py
@@ -1,6 +1,7 @@
 import unittest
 import subprocess
 import os
+import signal
 
 SECTOOLS = os.environ.get("SECVAR_TOOL", "../bin/secvarctl-dbg")
 SECVARPATH = "/sys/firmware/secvar/vars/"
@@ -31,7 +32,11 @@ class SecvarctlTest(unittest.TestCase):
             print(f"Error in command '{' '.join(args)}")
             raise e
 
-        return CommandOutput(out)
+        ret = CommandOutput(out)
+        if out.returncode < 0:
+            sig = signal.Signals(-out.returncode).name
+            self.assertTrue(out.returncode >= 0, msg=f"Command exited via signal {sig}: '{' '.join(args)}'\n{ret}'")
+        return ret
 
     def assertCmd(self, args, expected: bool):
         tmp_assert, msg = {

--- a/test/guest_tests.py
+++ b/test/guest_tests.py
@@ -172,6 +172,23 @@ class Test(SecvarctlTest):
     #             f.write(f"POWER SECVAR LOCATION( {SECVARPATH} ) DOES NOT EXIST SO NO TESTS RAN\n")
     #             f.close()
 
+    def test_malformed_generate(self):
+        cert = cert_files[0]  # arbitrarily use the first cert for testing
+
+        # Generate without a inform:outform should fail
+        cmd = list(filter(lambda x: x, generate_esl("db", "", cert, "foo.esl")))
+        self.assertCmdFalse(cmd)
+
+        # Generate with bad inform:output should fail
+        cmd.append("beans")
+        self.assertCmdFalse(cmd)
+        cmd.pop(-1)
+
+        # Generate with more than one inform:outform should also fail
+        cmd.append("c:e")
+        cmd.append("c:e")
+        self.assertCmdFalse(cmd)
+
     def test_generate_esl_files(self):
         for var_name in variables:
             esl_file = gen_dir + var_name + ".esl"


### PR DESCRIPTION
Fixes #80 

Argp calls the `parse_options()` function for each argument, therefore the logic to reject the append flag on a PK was evaluated for other arguments. Move the append flag reject logic outside of the argument parser, since it only needs to be evaluated once anyway, after all arguments have been read.

---

While solving the above, I noticed that the positional format specifier argument parsing logic was fairly... lacking. It led to some confusing error messages, as the original test case was using the old `-a 0` syntax for specifying the append header. The `0` was treated as a positional argument, and therefore was expected to be in the `c:a` format. Since it was _not_, it overwrote the previously valid `c:a` format specifier with `NULL`s, leading to an error in the format specifier, NOT in an unexpected argument.

The second commit addresses this, by adding some immediate enforcement of the format specifier, returning an error if it does not fit, or if another positional argument is supplied.