### PR TITLE
Don't attempt to print an ESL from a zero-sized buffer

### DIFF
--- a/backends/guest/common/read.c
+++ b/backends/guest/common/read.c
@@ -197,6 +197,12 @@ int print_esl_buffer(const uint8_t *buffer, size_t buffer_size, const char *var_
 	} curr_esl;
 	curr_esl.raw = NULL;
 
+	// Do not bother reading from zero-size buffers
+	if (buffer_size == 0) {
+		printf("(empty)\n");
+		return SUCCESS;
+	}
+
 	rc = next_esl_from_buffer(buffer, buffer_size, &curr_esl.raw, &esl_data_size);
 	if (rc) {
 		prlog(PR_ERR, "Error reading from esl buffer: %d\n", rc);


### PR DESCRIPTION
Minor fix. In guest mode, when printing a variable that has been cleared, a scary error message is printed claiming there is no remaining space to unpack an ESL.
```
$ ./bin/secvarctl -m guest read -n dbx -p tmp
READING dbx :
	Timestamp: 2023-04-07 09:18:56 UTC
Not enough space left for an ESL when unpacking buffer: 0 bytes remain
Error reading from esl buffer: 1
RESULT: FAILURE
```

Since the variable has been cleared, there obviously is no data, therefore the buffer is empty, however there is still the timestamp that should be printed. Therefore, handle cases when printing an empty buffer to indicate that there is no data to print:
```
$ ./bin/secvarctl -m guest read -n dbx -p tmp
make: Nothing to be done for 'all'.
READING dbx :
	Timestamp: 2023-04-07 09:18:56 UTC
(empty)
RESULT: SUCCESS
```

I'm open to changing or omitting the `(empty)` string, figured it was better to be explicit about the lack of data.
