### PR TITLE
Added fix for secvarctl-dbg directory in guest_generate_testdata.py

### DIFF
--- a/test/guest_generate_testdata.py
+++ b/test/guest_generate_testdata.py
@@ -53,7 +53,7 @@ log_dir = "./log"
 if len(sys.argv)>1:
 	secvarctl = [sys.argv[1]]
 else:
-	secvarctl = ["../../bin/secvarctl-dbg"]
+	secvarctl = ["../bin/secvarctl-dbg"]
 
 secvarctl = secvarctl + ["-m", "guest", "generate"]
 


### PR DESCRIPTION
Added directory fix for the given error- No such file or directory: '../../bin/secvarctl-dbg'.
****
Error Log:- 
[root@ test]# python3 guest_generate_testdata.py
Traceback (most recent call last):
  File "/home/secvarctl/test/guest_generate_testdata.py", line 244, in <module>
    create_goldenkey_files ()
  File "/home/secvarctl/test/guest_generate_testdata.py", line 135, in create_goldenkey_files
    generate_esl (var_name, format_type, cert_file, esl_file)
  File "/home/secvarctl/test/guest_generate_testdata.py", line 80, in generate_esl
    command (secvarctl + [format_type, "-i", cert_file, "-o", esl_file, "-n", variable_name])
  File "/home/secvarctl/test/guest_generate_testdata.py", line 61, in command
    return subprocess.call (args, stderr=err, stdout=out)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/subprocess.py", line 389, in call
    with Popen(*popenargs, **kwargs) as p:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/subprocess.py", line 1026, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.12/subprocess.py", line 1955, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '../../bin/secvarctl-dbg'
****
After applying fix:
[root@ test]# python3 guest_generate_testdata.py
RESULT: SUCCESS
RESULT: SUCCESS



