### PR TITLE
treewide: remove SECVAR_CRYPRO_WRITE_FUNC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,6 @@ set( SECVARCTL_VERSION "${SECVARCTL_VERSION_MAJOR}.${SECVARCTL_VERSION_MINOR}.${
 message( STATUS "Detected version string as ${SECVARCTL_VERSION}" )
 
 target_compile_definitions( secvarctl PRIVATE
-  SECVAR_CRYPTO_WRITE_FUNC
   SECVARCTL_VERSION=\"${SECVARCTL_VERSION}\"
 )
 

--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,6 @@ INCLUDES = -I.                                       \
            -I./external/libstb-secvar/include/secvar \
            -I./external/libstb-secvar/external
 
-#use CRYPTO_READ_ONLY for smaller executable but limited functionality
-#removes all write functions (secvarctl generate, pem_to_der etc.)
-CRYPTO_READ_ONLY = 0
-ifeq ($(strip $(CRYPTO_READ_ONLY)), 0)
-  _CFLAGS += -DSECVAR_CRYPTO_WRITE_FUNC
-endif
-
 # Set build version string
 include VERSION
 _CFLAGS += -DSECVARCTL_VERSION=\"$(SECVARCTL_VERSION)\"
@@ -141,7 +134,7 @@ $(BIN_DIR)/secvarctl-dbg: $(OBJDBG) $(LIBSTB_SECVAR)
 	$(CC) $(_CFLAGS) -g $^ $(STATICFLAG) $(SANITIZE_FLAGS) -fprofile-arcs -ftest-coverage -o $@ $(_LDFLAGS)
 
 $(LIBSTB_SECVAR):
-	$(MAKE) CFLAGS=-DSECVAR_CRYPTO_WRITE_FUNC -C $(LIBSTB_SECVAR_ROOT) lib/$(LIBSTB_SECVAR_ARCHIVE)
+	$(MAKE) -C $(LIBSTB_SECVAR_ROOT) lib/$(LIBSTB_SECVAR_ARCHIVE)
 
 
 secvarctl: $(BIN_DIR)/secvarctl

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Being that the key management process is rather lengthy and difficult, `secvarct
  | Static Build | `By Default Static build` |	`By Default Static build` |
  | Dynamic Build | `DYNAMIC_LIB=1` |	`-DDYNAMIC_LIB=1` |
  | Reduced Size Build | `default` | `-DSTRIP=1` |
- | Build Without Crypto Write Functions | `CRYPTO_READ_ONLY=1` | `-CRYPTO_READ_ONLY=1` |
  | Build W Specific Mbedtls Library | `CFLAGS="-I<path>/include" LDFLAGS="-L<path>/library"` | `-DCUSTOM_MBEDTLS=<path>` |
  | Build for Coverage Tests | `make [options] coverage` | `-DCoverage=1` |
  | Build W Debug Symbols | `make DEBUG=1` | `default` |

--- a/backends/guest/Makefile
+++ b/backends/guest/Makefile
@@ -21,13 +21,6 @@ else
   _LDFLAGS += -s
 endif
 
-#use CRYPTO_READ_ONLY for smaller executable but limited functionality
-#removes all write functions (secvarctl generate, pem_to_der etc.)
-CRYPTO_READ_ONLY = 0
-ifeq ($(strip $(CRYPTO_READ_ONLY)), 0)
-  _CFLAGS += -DSECVAR_CRYPTO_WRITE_FUNC
-endif
-
 DYNAMIC_LIB = 0
 STATIC_LIB = 1
 ifeq ($(strip $(DYNAMIC_LIB)), 1)
@@ -77,8 +70,7 @@ endif
 
 libstb-secvar:
 	@mkdir -p $(LIB_DIR)
-	@$(MAKE) -C $(GUEST_EXTERNAL_BACKEND_DIR) LIB_DIR=$(LIB_DIRS) STATIC_LIB=$(STATIC_LIB) \
-	            CRYPTO_READ_ONLY=$(CRYPTO_READ_ONLY)
+	@$(MAKE) -C $(GUEST_EXTERNAL_BACKEND_DIR) LIB_DIR=$(LIB_DIRS) STATIC_LIB=$(STATIC_LIB)
 
 clean:
 	@$(MAKE) -C $(GUEST_EXTERNAL_BACKEND_DIR) clean

--- a/backends/guest/common/validate.c
+++ b/backends/guest/common/validate.c
@@ -305,10 +305,8 @@ int validate_cert(const uint8_t *cert_data, size_t cert_data_len, bool is_CA)
 {
 	int rc;
 	crypto_x509_t *x509;
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 	uint8_t *cert = NULL;
 	size_t cert_size = 0;
-#endif
 
 	x509 = crypto_x509_parse_der(cert_data, cert_data_len);
 	if (!x509) {
@@ -317,7 +315,6 @@ int validate_cert(const uint8_t *cert_data, size_t cert_data_len, bool is_CA)
        * check if we have compiled with pkcs7_write functions
        * if so we can try to convert pem to der and try again
        */
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 		prlog(PR_INFO, "failed to parse x509 as DER, trying PEM...\n");
 		rc = crypto_convert_pem_to_der(cert_data, cert_data_len, &cert, &cert_size);
 		if (rc != CRYPTO_SUCCESS) {
@@ -330,10 +327,6 @@ int validate_cert(const uint8_t *cert_data, size_t cert_data_len, bool is_CA)
 		free(cert);
 		if (!x509)
 			return SV_X509_PARSE_ERROR;
-#else
-		prlog(PR_INFO, "ERROR: failed to parse x509. Make sure file is in DER not PEM\n");
-		return SV_X509_PARSE_ERROR;
-#endif
 	}
 
 	rc = validate_x509_certificate(x509);

--- a/backends/guest/guest_svc_generate.c
+++ b/backends/guest/guest_svc_generate.c
@@ -2,7 +2,6 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright 2022-2023 IBM Corp.
  */
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 #include <string.h>
 #include <argp.h>
 #include "err.h"
@@ -490,7 +489,7 @@ static int parse_options(int key, char *arg, struct argp_state *state)
 			break;
 		}
 		/* both forms should be either set or NULL, this should never be reached. */
-		if (!args->input_form ^ !args->output_form) {
+		if ((!args->input_form) ^ (!args->output_form)) {
 			prlog(PR_ERR,
 			      "ERROR: only one of input_form/output_form is set, this should not happen\n");
 			rc = ARG_PARSE_FAIL;
@@ -753,4 +752,3 @@ out:
 
 	return rc;
 }
-#endif

--- a/backends/guest/guest_svc_read.c
+++ b/backends/guest/guest_svc_read.c
@@ -102,7 +102,6 @@ static int read_cert(const uint8_t *cert_data, const size_t cert_data_len, const
        * check if we have compiled with pkcs7_write functions
        * if so we can try to convert pem to der and try again
        */
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 		uint8_t *cert;
 		size_t cert_size;
 		prlog(PR_INFO, "failed to parse x509 as DER, trying PEM...\n");
@@ -117,10 +116,6 @@ static int read_cert(const uint8_t *cert_data, const size_t cert_data_len, const
 		free(cert);
 		if (!x509)
 			return SV_X509_PARSE_ERROR;
-#else
-		prlog(PR_INFO, "ERROR: failed to parse x509. Make sure file is in DER not PEM\n");
-		return SV_X509_PARSE_ERROR;
-#endif
 	}
 
 	rc = validate_x509_certificate(x509);
@@ -479,7 +474,4 @@ struct command guest_command_table[] = { { .name = "read", .func = guest_read_co
 					 { .name = "write", .func = guest_write_command },
 					 { .name = "validate", .func = guest_validation_command },
 					 { .name = "verify", .func = guest_verify_command },
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
-					 { .name = "generate", .func = guest_generate_command }
-#endif
-};
+					 { .name = "generate", .func = guest_generate_command } };

--- a/backends/host/host_svc_generate.c
+++ b/backends/host/host_svc_generate.c
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 /* Copyright 2021 IBM Corp.*/
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -1125,4 +1124,3 @@ out:
 
 	return rc;
 }
-#endif

--- a/backends/host/host_svc_read.c
+++ b/backends/host/host_svc_read.c
@@ -569,7 +569,5 @@ struct command edk2_compat_command_table[] = {
 	{ .name = "write", .func = performWriteCommand },
 	{ .name = "validate", .func = performValidation },
 	{ .name = "verify", .func = performVerificationCommand },
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 	{ .name = "generate", .func = performGenerateCommand }
-#endif
 };

--- a/external/skiboot/libstb/secvar/crypto/crypto-gnutls.c
+++ b/external/skiboot/libstb/secvar/crypto/crypto-gnutls.c
@@ -216,7 +216,6 @@ out:
 }
 
 
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 /*
  *generates a PKCS7 and create signature with private and public keys
  *@param pkcs7, the resulting PKCS7 DER buff, newData not appended, NOTE: REMEMBER TO UNALLOC THIS MEMORY
@@ -413,7 +412,6 @@ int crypto_convert_pem_to_der(const unsigned char *input, size_t ilen,
     return rc;
 }
 
-#endif
 
 /**====================X509 Functions ====================**/
 int crypto_x509_get_der_len(crypto_x509_t *x509)

--- a/external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
+++ b/external/skiboot/libstb/secvar/crypto/crypto-mbedtls.c
@@ -21,13 +21,10 @@
 #include <mbedtls/oid.h>
 // Nick Child edited paths below
 // #include "libstb/crypto/pkcs7/pkcs7.h"
-// #ifdef SECVAR_CRYPTO_WRITE_FUNC
 // #include "libstb/crypto/pkcs7/pkcs7_write.h"
 // #endif
 #include "external/extraMbedtls/include/pkcs7.h"
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 #include "external/extraMbedtls/include/pkcs7_write.h"
-#endif
 #include <mbedtls/platform.h>
 
 crypto_pkcs7_t *crypto_pkcs7_parse_der(const unsigned char *buf, const int buflen)
@@ -86,7 +83,6 @@ int crypto_pkcs7_signed_hash_verify(crypto_pkcs7_t *pkcs7, crypto_x509_t *x509,
 	return mbedtls_pkcs7_signed_hash_verify(pkcs7, x509, hash, hash_len);
 }
 
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 int crypto_pkcs7_generate_w_signature(unsigned char **pkcs7, size_t *pkcs7Size,
 				      const unsigned char *newData,
 				      size_t newDataSize, const char **crtFiles,
@@ -232,7 +228,7 @@ int crypto_convert_pem_to_der(const unsigned char *input, size_t ilen,
 {
 	return mbedtls_convert_pem_to_der(input, ilen, output, olen);
 }
-#endif
+
 int crypto_x509_get_der_len(crypto_x509_t *x509)
 {
 	return x509->raw.len;

--- a/secvarctl.c
+++ b/secvarctl.c
@@ -88,11 +88,9 @@ void usage()
 	       "verify\t\tcompares proposed variable to the current "
 	       "variables,\n\t\t\t"
 	       "use 'secvarctl [MODE] verify --usage/help' for more information\n"
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 	       "\tgenerate\tcreates relevant files for secure variable "
 	       "management,\n\t\t\t"
 	       "use 'secvarctl [MODE] generate --usage/help' for more information\n"
-#endif
 	       "\n");
 	enabled_backends();
 }
@@ -110,11 +108,8 @@ void help()
 	       "type\n\t\t"
 	       "verify - checks that the given files are correctly signed by the "
 	       "current variables\n"
-#ifdef SECVAR_CRYPTO_WRITE_FUNC
 	       "\t\tgenerate - create files that are relevant to the secure "
-	       "variable management process\n"
-#endif
-	);
+	       "variable management process\n");
 
 	usage();
 }


### PR DESCRIPTION
Originally, SECVAR_CRYPTO_WRITE_FUNC was intended to be a compile-time flag to remove any generation code, to reduce the resulting binary file size to be as small as possible for management-only uses (such as in embedded firmware environment, like Petitboot).

Builds like these never came about, and this option only made builds more complex and error prone, so remove it.

Also fix a few cppcheck errors that popped up, since apparently not all branches were being checked.

Closes #83 